### PR TITLE
Allow users to specify expected values for validation failures

### DIFF
--- a/tests/src/test/resources/org/everit/json/schema/issues/issue36/expectedException.json
+++ b/tests/src/test/resources/org/everit/json/schema/issues/issue36/expectedException.json
@@ -1,0 +1,22 @@
+{
+  "message": "#: 4 schema violations found",
+  "causingExceptions": [
+     {
+        "message": "#/0: 2 schema violations found",
+        "causingExceptions": [
+           {
+              "message": "#/0/name: expected type: String, found: JSONArray"
+           },
+           {
+              "message": "#/0/dimensions/width: expected type: Number, found: String"
+           }
+        ]
+     },
+     {
+        "message": "#/1: required key [price] not found",
+     },
+     {
+        "message": "#/2/id: expected type: Number, found: String",
+     }
+  ]
+}

--- a/tests/src/test/resources/org/everit/json/schema/issues/issue36/schema.json
+++ b/tests/src/test/resources/org/everit/json/schema/issues/issue36/schema.json
@@ -1,0 +1,45 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "title": "Product set",
+    "type": "array",
+    "items": {
+        "title": "Product",
+        "type": "object",
+        "properties": {
+            "id": {
+                "description": "The unique identifier for a product",
+                "type": "number"
+            },
+            "name": {
+                "type": "string"
+            },
+            "price": {
+                "type": "number",
+                "minimum": 0,
+                "exclusiveMinimum": true
+            },
+            "tags": {
+                "type": "array",
+                "items": {
+                    "type": "string"
+                },
+                "minItems": 1,
+                "uniqueItems": true
+            },
+            "dimensions": {
+                "type": "object",
+                "properties": {
+                    "length": {"type": "number"},
+                    "width": {"type": "number"},
+                    "height": {"type": "number"}
+                },
+                "required": ["length", "width", "height"]
+            },
+            "warehouseLocation": {
+                "description": "Coordinates of the warehouse with the product",
+                "$ref": "http://json-schema.org/geo"
+            }
+        },
+        "required": ["id", "name", "price"]
+    }
+}

--- a/tests/src/test/resources/org/everit/json/schema/issues/issue36/subject-invalid.json
+++ b/tests/src/test/resources/org/everit/json/schema/issues/issue36/subject-invalid.json
@@ -1,0 +1,44 @@
+[
+    {
+        "id": 2,
+        "name": ["An ice sculpture"],
+        "price": 12.50,
+        "tags": ["cold", "ice"],
+        "dimensions": {
+            "length": 7.0,
+            "width": "12.0",
+            "height": 9.5
+        },
+        "warehouseLocation": {
+            "latitude": -78.75,
+            "longitude": 20.4
+        }
+    },
+    {
+        "id": 3,
+        "name": "A blue mouse",
+        "dimensions": {
+            "length": 3.1,
+            "width": 1.0,
+            "height": 1.0
+        },
+        "warehouseLocation": {
+            "latitude": 54.4,
+            "longitude": -32.7
+        }
+    },
+    {
+        "id": "4",
+        "name": "A little chick",
+        "price": 12.50,
+        "dimensions": {
+            "length": 3.1,
+            "width": 1.0,
+            "height": 1.0
+        },
+        "warehouseLocation": {
+            "latitude": 54.4,
+            "longitude": -32.7
+        }
+    }
+]


### PR DESCRIPTION
As discussed in Issue 36, I implemented the ability for a user to add an issue testcase and specify the exact validation failures that they are expecting to be generated by the library.  Along with these changes, I am submitting three new files under issue36/ that demonstrate the new functionality.  Note that the subject JSON file contains 4 validation failures. The library correctly finds all 4, but the top level summary message incorrectly states "3 validation failures".  This is a potential bug, to be determined by the maintainer based on the design of the library... see what you think. 

See the TODO comments also.  These are utility methods I added to IssueTest (processValidationFailures(), loadJsonFile()) that could be moved into the core project, so that users could use them as convenience methods.  If this were done, processValidationFailures() would need to be modified to return a List (of the validation failure strings).  Again, you can see what you think...

Regards,
Trevor
