### PR TITLE
add equals and hashcode for schema objects

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -100,5 +100,11 @@
       <version>1.10.19</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>nl.jqno.equalsverifier</groupId>
+      <artifactId>equalsverifier</artifactId>
+      <version>2.1.5</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/core/src/main/java/org/everit/json/schema/ArraySchema.java
+++ b/core/src/main/java/org/everit/json/schema/ArraySchema.java
@@ -17,6 +17,7 @@ package org.everit.json.schema;
 
 import org.json.JSONArray;
 
+import java.lang.reflect.Array;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -29,7 +30,7 @@ import java.util.stream.IntStream;
 /**
  * Array schema validator.
  */
-public final class ArraySchema extends Schema {
+public class ArraySchema extends Schema {
 
   /**
    * Builder class for {@link ArraySchema}.
@@ -292,23 +293,32 @@ public final class ArraySchema extends Schema {
   }
 
   @Override
-  public boolean equals(Object o) {
+  public final boolean equals(Object o) {
     if (this == o) return true;
-    if (o == null || getClass() != o.getClass()) return false;
-    if (!super.equals(o)) return false;
-    ArraySchema that = (ArraySchema) o;
-    return uniqueItems == that.uniqueItems &&
-            additionalItems == that.additionalItems &&
-            requiresArray == that.requiresArray &&
-            Objects.equals(minItems, that.minItems) &&
-            Objects.equals(maxItems, that.maxItems) &&
-            Objects.equals(allItemSchema, that.allItemSchema) &&
-            Objects.equals(itemSchemas, that.itemSchemas) &&
-            Objects.equals(schemaOfAdditionalItems, that.schemaOfAdditionalItems);
+      if (o instanceof ArraySchema) {
+        ArraySchema that = (ArraySchema) o;
+        return that.canEqual(this) &&
+                uniqueItems == that.uniqueItems &&
+                additionalItems == that.additionalItems &&
+                requiresArray == that.requiresArray &&
+                Objects.equals(minItems, that.minItems) &&
+                Objects.equals(maxItems, that.maxItems) &&
+                Objects.equals(allItemSchema, that.allItemSchema) &&
+                Objects.equals(itemSchemas, that.itemSchemas) &&
+                Objects.equals(schemaOfAdditionalItems, that.schemaOfAdditionalItems) &&
+                super.equals(o);
+      } else {
+        return false;
+    }
   }
 
   @Override
-  public int hashCode() {
+  protected boolean canEqual(Object other) {
+    return other instanceof ArraySchema;
+  }
+
+  @Override
+  public final int hashCode() {
     return Objects.hash(super.hashCode(), minItems, maxItems, uniqueItems, allItemSchema, additionalItems, itemSchemas, requiresArray, schemaOfAdditionalItems);
   }
 }

--- a/core/src/main/java/org/everit/json/schema/ArraySchema.java
+++ b/core/src/main/java/org/everit/json/schema/ArraySchema.java
@@ -29,7 +29,7 @@ import java.util.stream.IntStream;
 /**
  * Array schema validator.
  */
-public class ArraySchema extends Schema {
+public final class ArraySchema extends Schema {
 
   /**
    * Builder class for {@link ArraySchema}.
@@ -291,4 +291,24 @@ public class ArraySchema extends Schema {
     ValidationException.throwFor(this, failures);
   }
 
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    if (!super.equals(o)) return false;
+    ArraySchema that = (ArraySchema) o;
+    return uniqueItems == that.uniqueItems &&
+            additionalItems == that.additionalItems &&
+            requiresArray == that.requiresArray &&
+            Objects.equals(minItems, that.minItems) &&
+            Objects.equals(maxItems, that.maxItems) &&
+            Objects.equals(allItemSchema, that.allItemSchema) &&
+            Objects.equals(itemSchemas, that.itemSchemas) &&
+            Objects.equals(schemaOfAdditionalItems, that.schemaOfAdditionalItems);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(super.hashCode(), minItems, maxItems, uniqueItems, allItemSchema, additionalItems, itemSchemas, requiresArray, schemaOfAdditionalItems);
+  }
 }

--- a/core/src/main/java/org/everit/json/schema/ArraySchema.java
+++ b/core/src/main/java/org/everit/json/schema/ArraySchema.java
@@ -293,7 +293,7 @@ public class ArraySchema extends Schema {
   }
 
   @Override
-  public final boolean equals(Object o) {
+  public boolean equals(Object o) {
     if (this == o) return true;
       if (o instanceof ArraySchema) {
         ArraySchema that = (ArraySchema) o;
@@ -318,7 +318,7 @@ public class ArraySchema extends Schema {
   }
 
   @Override
-  public final int hashCode() {
+  public int hashCode() {
     return Objects.hash(super.hashCode(), minItems, maxItems, uniqueItems, allItemSchema, additionalItems, itemSchemas, requiresArray, schemaOfAdditionalItems);
   }
 }

--- a/core/src/main/java/org/everit/json/schema/BooleanSchema.java
+++ b/core/src/main/java/org/everit/json/schema/BooleanSchema.java
@@ -18,7 +18,7 @@ package org.everit.json.schema;
 /**
  * Boolean schema validator.
  */
-public class BooleanSchema extends Schema {
+public final class BooleanSchema extends Schema {
 
   /**
    * Builder class for {@link BooleanSchema}.
@@ -47,6 +47,14 @@ public class BooleanSchema extends Schema {
     if (!(subject instanceof Boolean)) {
       throw new ValidationException(this, Boolean.class, subject);
     }
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    if (!super.equals(o)) return false;
+      return true;
   }
 
 }

--- a/core/src/main/java/org/everit/json/schema/BooleanSchema.java
+++ b/core/src/main/java/org/everit/json/schema/BooleanSchema.java
@@ -52,7 +52,7 @@ public class BooleanSchema extends Schema {
   }
 
   @Override
-  public final boolean equals(Object o) {
+  public boolean equals(Object o) {
     if (this == o) return true;
     if (o instanceof BooleanSchema) {
       BooleanSchema that = (BooleanSchema) o;
@@ -63,7 +63,7 @@ public class BooleanSchema extends Schema {
   }
 
   @Override
-  public final int hashCode() {
+  public int hashCode() {
     return super.hashCode();
   }
 

--- a/core/src/main/java/org/everit/json/schema/BooleanSchema.java
+++ b/core/src/main/java/org/everit/json/schema/BooleanSchema.java
@@ -15,10 +15,12 @@
  */
 package org.everit.json.schema;
 
+import com.sun.org.apache.xpath.internal.operations.Bool;
+
 /**
  * Boolean schema validator.
  */
-public final class BooleanSchema extends Schema {
+public class BooleanSchema extends Schema {
 
   /**
    * Builder class for {@link BooleanSchema}.
@@ -50,11 +52,23 @@ public final class BooleanSchema extends Schema {
   }
 
   @Override
-  public boolean equals(Object o) {
+  public final boolean equals(Object o) {
     if (this == o) return true;
-    if (o == null || getClass() != o.getClass()) return false;
-    if (!super.equals(o)) return false;
-      return true;
+    if (o instanceof BooleanSchema) {
+      BooleanSchema that = (BooleanSchema) o;
+      return that.canEqual(this) && super.equals(that);
+    } else {
+      return false;
+    }
   }
 
+  @Override
+  public final int hashCode() {
+    return super.hashCode();
+  }
+
+  @Override
+  protected boolean canEqual(Object other) {
+    return other instanceof BooleanSchema;
+  }
 }

--- a/core/src/main/java/org/everit/json/schema/CombinedSchema.java
+++ b/core/src/main/java/org/everit/json/schema/CombinedSchema.java
@@ -193,7 +193,7 @@ public class CombinedSchema extends Schema {
   }
 
   @Override
-  public final boolean equals(Object o) {
+  public boolean equals(Object o) {
     if (this == o) return true;
     if (o instanceof CombinedSchema) {
       CombinedSchema that = (CombinedSchema) o;
@@ -207,7 +207,7 @@ public class CombinedSchema extends Schema {
   }
 
   @Override
-  public final int hashCode() {
+  public int hashCode() {
     return Objects.hash(super.hashCode(), subschemas, criterion);
   }
 

--- a/core/src/main/java/org/everit/json/schema/CombinedSchema.java
+++ b/core/src/main/java/org/everit/json/schema/CombinedSchema.java
@@ -24,7 +24,7 @@ import java.util.stream.Collectors;
 /**
  * Validator for {@code allOf}, {@code oneOf}, {@code anyOf} schemas.
  */
-public class CombinedSchema extends Schema {
+public final class CombinedSchema extends Schema {
 
   /**
    * Builder class for {@link CombinedSchema}.
@@ -190,5 +190,20 @@ public class CombinedSchema extends Schema {
       return false;
     }
     return true;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    if (!super.equals(o)) return false;
+    CombinedSchema that = (CombinedSchema) o;
+    return Objects.equals(subschemas, that.subschemas) &&
+            Objects.equals(criterion, that.criterion);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(super.hashCode(), subschemas, criterion);
   }
 }

--- a/core/src/main/java/org/everit/json/schema/CombinedSchema.java
+++ b/core/src/main/java/org/everit/json/schema/CombinedSchema.java
@@ -24,7 +24,7 @@ import java.util.stream.Collectors;
 /**
  * Validator for {@code allOf}, {@code oneOf}, {@code anyOf} schemas.
  */
-public final class CombinedSchema extends Schema {
+public class CombinedSchema extends Schema {
 
   /**
    * Builder class for {@link CombinedSchema}.
@@ -193,17 +193,26 @@ public final class CombinedSchema extends Schema {
   }
 
   @Override
-  public boolean equals(Object o) {
+  public final boolean equals(Object o) {
     if (this == o) return true;
-    if (o == null || getClass() != o.getClass()) return false;
-    if (!super.equals(o)) return false;
-    CombinedSchema that = (CombinedSchema) o;
-    return Objects.equals(subschemas, that.subschemas) &&
-            Objects.equals(criterion, that.criterion);
+    if (o instanceof CombinedSchema) {
+      CombinedSchema that = (CombinedSchema) o;
+      return that.canEqual(this) &&
+              Objects.equals(subschemas, that.subschemas) &&
+              Objects.equals(criterion, that.criterion) &&
+              super.equals(that);
+    } else {
+      return false;
+    }
   }
 
   @Override
-  public int hashCode() {
+  public final int hashCode() {
     return Objects.hash(super.hashCode(), subschemas, criterion);
+  }
+
+  @Override
+  protected boolean canEqual(Object other) {
+    return other instanceof CombinedSchema;
   }
 }

--- a/core/src/main/java/org/everit/json/schema/EmptySchema.java
+++ b/core/src/main/java/org/everit/json/schema/EmptySchema.java
@@ -18,7 +18,7 @@ package org.everit.json.schema;
 /**
  * A schema not specifying any restrictions, ie. accepting any values.
  */
-public final class EmptySchema extends Schema {
+public class EmptySchema extends Schema {
 
   public static final EmptySchema INSTANCE = new EmptySchema(builder());
 
@@ -48,10 +48,23 @@ public final class EmptySchema extends Schema {
   }
 
   @Override
-  public boolean equals(Object o) {
+  public final boolean equals(Object o) {
     if (this == o) return true;
-    if (o == null || getClass() != o.getClass()) return false;
-    return super.equals(o);
+    if (o instanceof EmptySchema) {
+      EmptySchema that = (EmptySchema) o;
+      return that.canEqual(this) && super.equals(that);
+    } else {
+      return false;
+    }
   }
 
+  @Override
+  protected boolean canEqual(Object other) {
+    return other instanceof EmptySchema;
+  }
+
+  @Override
+  public final int hashCode() {
+      return super.hashCode();
+  }
 }

--- a/core/src/main/java/org/everit/json/schema/EmptySchema.java
+++ b/core/src/main/java/org/everit/json/schema/EmptySchema.java
@@ -48,7 +48,7 @@ public class EmptySchema extends Schema {
   }
 
   @Override
-  public final boolean equals(Object o) {
+  public boolean equals(Object o) {
     if (this == o) return true;
     if (o instanceof EmptySchema) {
       EmptySchema that = (EmptySchema) o;
@@ -64,7 +64,7 @@ public class EmptySchema extends Schema {
   }
 
   @Override
-  public final int hashCode() {
+  public int hashCode() {
       return super.hashCode();
   }
 }

--- a/core/src/main/java/org/everit/json/schema/EmptySchema.java
+++ b/core/src/main/java/org/everit/json/schema/EmptySchema.java
@@ -18,7 +18,7 @@ package org.everit.json.schema;
 /**
  * A schema not specifying any restrictions, ie. accepting any values.
  */
-public class EmptySchema extends Schema {
+public final class EmptySchema extends Schema {
 
   public static final EmptySchema INSTANCE = new EmptySchema(builder());
 
@@ -45,6 +45,13 @@ public class EmptySchema extends Schema {
   @Override
   public void validate(final Object subject) {
     // always passing
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    return super.equals(o);
   }
 
 }

--- a/core/src/main/java/org/everit/json/schema/EnumSchema.java
+++ b/core/src/main/java/org/everit/json/schema/EnumSchema.java
@@ -24,7 +24,7 @@ import java.util.Set;
  * Enum schema validator.
  *
  */
-public final class EnumSchema extends Schema {
+public class EnumSchema extends Schema {
 
   /**
    * Builder class for {@link EnumSchema}.
@@ -76,16 +76,25 @@ public final class EnumSchema extends Schema {
   }
 
   @Override
-  public boolean equals(Object o) {
+  public final boolean equals(Object o) {
     if (this == o) return true;
-    if (o == null || getClass() != o.getClass()) return false;
-    if (!super.equals(o)) return false;
-    EnumSchema that = (EnumSchema) o;
-    return Objects.equals(possibleValues, that.possibleValues);
+    if (o instanceof EnumSchema) {
+      EnumSchema that = (EnumSchema) o;
+      return that.canEqual(this) &&
+              Objects.equals(possibleValues, that.possibleValues) &&
+              super.equals(that);
+    } else {
+      return false;
+    }
   }
 
   @Override
-  public int hashCode() {
+  public final int hashCode() {
     return Objects.hash(super.hashCode(), possibleValues);
+  }
+
+  @Override
+  protected boolean canEqual(Object other) {
+    return other instanceof EnumSchema;
   }
 }

--- a/core/src/main/java/org/everit/json/schema/EnumSchema.java
+++ b/core/src/main/java/org/everit/json/schema/EnumSchema.java
@@ -76,7 +76,7 @@ public class EnumSchema extends Schema {
   }
 
   @Override
-  public final boolean equals(Object o) {
+  public boolean equals(Object o) {
     if (this == o) return true;
     if (o instanceof EnumSchema) {
       EnumSchema that = (EnumSchema) o;
@@ -89,7 +89,7 @@ public class EnumSchema extends Schema {
   }
 
   @Override
-  public final int hashCode() {
+  public int hashCode() {
     return Objects.hash(super.hashCode(), possibleValues);
   }
 

--- a/core/src/main/java/org/everit/json/schema/EnumSchema.java
+++ b/core/src/main/java/org/everit/json/schema/EnumSchema.java
@@ -17,13 +17,14 @@ package org.everit.json.schema;
 
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.Objects;
 import java.util.Set;
 
 /**
  * Enum schema validator.
  *
  */
-public class EnumSchema extends Schema {
+public final class EnumSchema extends Schema {
 
   /**
    * Builder class for {@link EnumSchema}.
@@ -74,4 +75,17 @@ public class EnumSchema extends Schema {
                 subject), "enum"));
   }
 
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    if (!super.equals(o)) return false;
+    EnumSchema that = (EnumSchema) o;
+    return Objects.equals(possibleValues, that.possibleValues);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(super.hashCode(), possibleValues);
+  }
 }

--- a/core/src/main/java/org/everit/json/schema/NotSchema.java
+++ b/core/src/main/java/org/everit/json/schema/NotSchema.java
@@ -20,7 +20,7 @@ import java.util.Objects;
 /**
  * {@code Not} schema validator.
  */
-public class NotSchema extends Schema {
+public final class NotSchema extends Schema {
 
   /**
    * Builder class for {@link NotSchema}.
@@ -63,4 +63,17 @@ public class NotSchema extends Schema {
         "not");
   }
 
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    if (!super.equals(o)) return false;
+    NotSchema notSchema = (NotSchema) o;
+    return Objects.equals(mustNotMatch, notSchema.mustNotMatch);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(super.hashCode(), mustNotMatch);
+  }
 }

--- a/core/src/main/java/org/everit/json/schema/NotSchema.java
+++ b/core/src/main/java/org/everit/json/schema/NotSchema.java
@@ -20,7 +20,7 @@ import java.util.Objects;
 /**
  * {@code Not} schema validator.
  */
-public final class NotSchema extends Schema {
+public class NotSchema extends Schema {
 
   /**
    * Builder class for {@link NotSchema}.
@@ -64,16 +64,25 @@ public final class NotSchema extends Schema {
   }
 
   @Override
-  public boolean equals(Object o) {
+  public final boolean equals(Object o) {
     if (this == o) return true;
-    if (o == null || getClass() != o.getClass()) return false;
-    if (!super.equals(o)) return false;
-    NotSchema notSchema = (NotSchema) o;
-    return Objects.equals(mustNotMatch, notSchema.mustNotMatch);
+    if (o instanceof NotSchema) {
+      NotSchema that = (NotSchema) o;
+      return that.canEqual(this) &&
+              Objects.equals(mustNotMatch, that.mustNotMatch) &&
+              super.equals(that);
+    } else {
+      return false;
+    }
   }
 
   @Override
-  public int hashCode() {
+  public final int hashCode() {
     return Objects.hash(super.hashCode(), mustNotMatch);
+  }
+
+  @Override
+  protected boolean canEqual(Object other) {
+    return other instanceof NotSchema;
   }
 }

--- a/core/src/main/java/org/everit/json/schema/NotSchema.java
+++ b/core/src/main/java/org/everit/json/schema/NotSchema.java
@@ -64,7 +64,7 @@ public class NotSchema extends Schema {
   }
 
   @Override
-  public final boolean equals(Object o) {
+  public boolean equals(Object o) {
     if (this == o) return true;
     if (o instanceof NotSchema) {
       NotSchema that = (NotSchema) o;
@@ -77,7 +77,7 @@ public class NotSchema extends Schema {
   }
 
   @Override
-  public final int hashCode() {
+  public int hashCode() {
     return Objects.hash(super.hashCode(), mustNotMatch);
   }
 

--- a/core/src/main/java/org/everit/json/schema/NullSchema.java
+++ b/core/src/main/java/org/everit/json/schema/NullSchema.java
@@ -52,7 +52,7 @@ public class NullSchema extends Schema {
   }
 
   @Override
-  public final boolean equals(Object o) {
+  public boolean equals(Object o) {
     if (this == o) return true;
     if (o instanceof NullSchema) {
       NullSchema that = (NullSchema) o;
@@ -63,7 +63,7 @@ public class NullSchema extends Schema {
   }
 
   @Override
-  public final int hashCode() {
+  public int hashCode() {
     return super.hashCode();
   }
 

--- a/core/src/main/java/org/everit/json/schema/NullSchema.java
+++ b/core/src/main/java/org/everit/json/schema/NullSchema.java
@@ -20,7 +20,7 @@ import org.json.JSONObject;
 /**
  * {@code Null} schema validator.
  */
-public final class NullSchema extends Schema {
+public class NullSchema extends Schema {
 
   /**
    * Builder class for {@link NullSchema}.
@@ -52,10 +52,23 @@ public final class NullSchema extends Schema {
   }
 
   @Override
-  public boolean equals(Object o) {
+  public final boolean equals(Object o) {
     if (this == o) return true;
-    if (o == null || getClass() != o.getClass()) return false;
-    return super.equals(o);
+    if (o instanceof NullSchema) {
+      NullSchema that = (NullSchema) o;
+      return that.canEqual(this) && super.equals(that);
+    } else {
+      return false;
+    }
   }
 
+  @Override
+  public final int hashCode() {
+    return super.hashCode();
+  }
+
+  @Override
+  protected boolean canEqual(Object other) {
+    return other instanceof NullSchema;
+  }
 }

--- a/core/src/main/java/org/everit/json/schema/NullSchema.java
+++ b/core/src/main/java/org/everit/json/schema/NullSchema.java
@@ -20,7 +20,7 @@ import org.json.JSONObject;
 /**
  * {@code Null} schema validator.
  */
-public class NullSchema extends Schema {
+public final class NullSchema extends Schema {
 
   /**
    * Builder class for {@link NullSchema}.
@@ -49,6 +49,13 @@ public class NullSchema extends Schema {
       throw new ValidationException(this, "expected: null, found: "
           + subject.getClass().getSimpleName(), "type");
     }
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    return super.equals(o);
   }
 
 }

--- a/core/src/main/java/org/everit/json/schema/NumberSchema.java
+++ b/core/src/main/java/org/everit/json/schema/NumberSchema.java
@@ -21,7 +21,7 @@ import java.util.Objects;
 /**
  * Number schema validator.
  */
-public final class NumberSchema extends Schema {
+public class NumberSchema extends Schema {
 
   /**
    * Builder class for {@link NumberSchema}.
@@ -200,22 +200,31 @@ public final class NumberSchema extends Schema {
   }
 
   @Override
-  public boolean equals(Object o) {
+  public final boolean equals(Object o) {
     if (this == o) return true;
-    if (o == null || getClass() != o.getClass()) return false;
-    if (!super.equals(o)) return false;
-    NumberSchema that = (NumberSchema) o;
-    return requiresNumber == that.requiresNumber &&
-            exclusiveMinimum == that.exclusiveMinimum &&
-            exclusiveMaximum == that.exclusiveMaximum &&
-            requiresInteger == that.requiresInteger &&
-            Objects.equals(minimum, that.minimum) &&
-            Objects.equals(maximum, that.maximum) &&
-            Objects.equals(multipleOf, that.multipleOf);
+    if (o instanceof NumberSchema) {
+      NumberSchema that = (NumberSchema) o;
+      return that.canEqual(this) &&
+              requiresNumber == that.requiresNumber &&
+              exclusiveMinimum == that.exclusiveMinimum &&
+              exclusiveMaximum == that.exclusiveMaximum &&
+              requiresInteger == that.requiresInteger &&
+              Objects.equals(minimum, that.minimum) &&
+              Objects.equals(maximum, that.maximum) &&
+              Objects.equals(multipleOf, that.multipleOf) &&
+              super.equals(that);
+    } else {
+      return false;
+    }
   }
 
   @Override
-  public int hashCode() {
+  public final int hashCode() {
     return Objects.hash(super.hashCode(), requiresNumber, minimum, maximum, multipleOf, exclusiveMinimum, exclusiveMaximum, requiresInteger);
+  }
+
+  @Override
+  protected boolean canEqual(Object other) {
+    return other instanceof NumberSchema;
   }
 }

--- a/core/src/main/java/org/everit/json/schema/NumberSchema.java
+++ b/core/src/main/java/org/everit/json/schema/NumberSchema.java
@@ -200,7 +200,7 @@ public class NumberSchema extends Schema {
   }
 
   @Override
-  public final boolean equals(Object o) {
+  public boolean equals(Object o) {
     if (this == o) return true;
     if (o instanceof NumberSchema) {
       NumberSchema that = (NumberSchema) o;
@@ -219,7 +219,7 @@ public class NumberSchema extends Schema {
   }
 
   @Override
-  public final int hashCode() {
+  public int hashCode() {
     return Objects.hash(super.hashCode(), requiresNumber, minimum, maximum, multipleOf, exclusiveMinimum, exclusiveMaximum, requiresInteger);
   }
 

--- a/core/src/main/java/org/everit/json/schema/NumberSchema.java
+++ b/core/src/main/java/org/everit/json/schema/NumberSchema.java
@@ -16,11 +16,12 @@
 package org.everit.json.schema;
 
 import java.math.BigDecimal;
+import java.util.Objects;
 
 /**
  * Number schema validator.
  */
-public class NumberSchema extends Schema {
+public final class NumberSchema extends Schema {
 
   /**
    * Builder class for {@link NumberSchema}.
@@ -95,9 +96,9 @@ public class NumberSchema extends Schema {
 
   private final Number multipleOf;
 
-  private boolean exclusiveMinimum = false;
+  private final boolean exclusiveMinimum;
 
-  private boolean exclusiveMaximum = false;
+  private final boolean exclusiveMaximum;
 
   private final boolean requiresInteger;
 
@@ -198,4 +199,23 @@ public class NumberSchema extends Schema {
     }
   }
 
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    if (!super.equals(o)) return false;
+    NumberSchema that = (NumberSchema) o;
+    return requiresNumber == that.requiresNumber &&
+            exclusiveMinimum == that.exclusiveMinimum &&
+            exclusiveMaximum == that.exclusiveMaximum &&
+            requiresInteger == that.requiresInteger &&
+            Objects.equals(minimum, that.minimum) &&
+            Objects.equals(maximum, that.maximum) &&
+            Objects.equals(multipleOf, that.multipleOf);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(super.hashCode(), requiresNumber, minimum, maximum, multipleOf, exclusiveMinimum, exclusiveMaximum, requiresInteger);
+  }
 }

--- a/core/src/main/java/org/everit/json/schema/ObjectSchema.java
+++ b/core/src/main/java/org/everit/json/schema/ObjectSchema.java
@@ -35,7 +35,7 @@ import org.json.JSONObject;
 /**
  * Object schema validator.
  */
-public final class ObjectSchema extends Schema {
+public class ObjectSchema extends Schema {
 
   /**
    * Builder class for {@link ObjectSchema}.
@@ -445,25 +445,34 @@ public final class ObjectSchema extends Schema {
   }
 
   @Override
-  public boolean equals(Object o) {
+  public final boolean equals(Object o) {
     if (this == o) return true;
-    if (o == null || getClass() != o.getClass()) return false;
-    if (!super.equals(o)) return false;
-    ObjectSchema that = (ObjectSchema) o;
-    return additionalProperties == that.additionalProperties &&
-            requiresObject == that.requiresObject &&
-            Objects.equals(propertySchemas, that.propertySchemas) &&
-            Objects.equals(schemaOfAdditionalProperties, that.schemaOfAdditionalProperties) &&
-            Objects.equals(requiredProperties, that.requiredProperties) &&
-            Objects.equals(minProperties, that.minProperties) &&
-            Objects.equals(maxProperties, that.maxProperties) &&
-            Objects.equals(propertyDependencies, that.propertyDependencies) &&
-            Objects.equals(schemaDependencies, that.schemaDependencies) &&
-            Objects.equals(patternProperties, that.patternProperties);
+    if (o instanceof ObjectSchema) {
+      ObjectSchema that = (ObjectSchema) o;
+      return that.canEqual(this) &&
+              additionalProperties == that.additionalProperties &&
+              requiresObject == that.requiresObject &&
+              Objects.equals(propertySchemas, that.propertySchemas) &&
+              Objects.equals(schemaOfAdditionalProperties, that.schemaOfAdditionalProperties) &&
+              Objects.equals(requiredProperties, that.requiredProperties) &&
+              Objects.equals(minProperties, that.minProperties) &&
+              Objects.equals(maxProperties, that.maxProperties) &&
+              Objects.equals(propertyDependencies, that.propertyDependencies) &&
+              Objects.equals(schemaDependencies, that.schemaDependencies) &&
+              Objects.equals(patternProperties, that.patternProperties) &&
+              super.equals(that);
+    } else {
+      return false;
+    }
   }
 
   @Override
-  public int hashCode() {
+  public final int hashCode() {
     return Objects.hash(super.hashCode(), propertySchemas, additionalProperties, schemaOfAdditionalProperties, requiredProperties, minProperties, maxProperties, propertyDependencies, schemaDependencies, requiresObject, patternProperties);
+  }
+
+  @Override
+  protected boolean canEqual(Object other) {
+    return other instanceof ObjectSchema;
   }
 }

--- a/core/src/main/java/org/everit/json/schema/ObjectSchema.java
+++ b/core/src/main/java/org/everit/json/schema/ObjectSchema.java
@@ -445,7 +445,7 @@ public class ObjectSchema extends Schema {
   }
 
   @Override
-  public final boolean equals(Object o) {
+  public boolean equals(Object o) {
     if (this == o) return true;
     if (o instanceof ObjectSchema) {
       ObjectSchema that = (ObjectSchema) o;
@@ -467,7 +467,7 @@ public class ObjectSchema extends Schema {
   }
 
   @Override
-  public final int hashCode() {
+  public int hashCode() {
     return Objects.hash(super.hashCode(), propertySchemas, additionalProperties, schemaOfAdditionalProperties, requiredProperties, minProperties, maxProperties, propertyDependencies, schemaDependencies, requiresObject, patternProperties);
   }
 

--- a/core/src/main/java/org/everit/json/schema/ObjectSchema.java
+++ b/core/src/main/java/org/everit/json/schema/ObjectSchema.java
@@ -35,7 +35,7 @@ import org.json.JSONObject;
 /**
  * Object schema validator.
  */
-public class ObjectSchema extends Schema {
+public final class ObjectSchema extends Schema {
 
   /**
    * Builder class for {@link ObjectSchema}.
@@ -444,4 +444,26 @@ public class ObjectSchema extends Schema {
     return value.replace("~1", "/").replace("~0", "~");
   }
 
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    if (!super.equals(o)) return false;
+    ObjectSchema that = (ObjectSchema) o;
+    return additionalProperties == that.additionalProperties &&
+            requiresObject == that.requiresObject &&
+            Objects.equals(propertySchemas, that.propertySchemas) &&
+            Objects.equals(schemaOfAdditionalProperties, that.schemaOfAdditionalProperties) &&
+            Objects.equals(requiredProperties, that.requiredProperties) &&
+            Objects.equals(minProperties, that.minProperties) &&
+            Objects.equals(maxProperties, that.maxProperties) &&
+            Objects.equals(propertyDependencies, that.propertyDependencies) &&
+            Objects.equals(schemaDependencies, that.schemaDependencies) &&
+            Objects.equals(patternProperties, that.patternProperties);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(super.hashCode(), propertySchemas, additionalProperties, schemaOfAdditionalProperties, requiredProperties, minProperties, maxProperties, propertyDependencies, schemaDependencies, requiresObject, patternProperties);
+  }
 }

--- a/core/src/main/java/org/everit/json/schema/ReferenceSchema.java
+++ b/core/src/main/java/org/everit/json/schema/ReferenceSchema.java
@@ -15,12 +15,14 @@
  */
 package org.everit.json.schema;
 
+import java.util.Objects;
+
 /**
  * This class is used by {@link org.everit.json.schema.loader.SchemaLoader} to resolve JSON pointers
  * during the construction of the schema. This class has been made mutable to permit the loading of
  * recursive schemas.
  */
-public class ReferenceSchema extends Schema {
+public final class ReferenceSchema extends Schema {
 
   /**
    * Builder class for {@link ReferenceSchema}.
@@ -87,4 +89,17 @@ public class ReferenceSchema extends Schema {
     this.referredSchema = referredSchema;
   }
 
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    if (!super.equals(o)) return false;
+    ReferenceSchema that = (ReferenceSchema) o;
+    return Objects.equals(referredSchema, that.referredSchema);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(super.hashCode(), referredSchema);
+  }
 }

--- a/core/src/main/java/org/everit/json/schema/ReferenceSchema.java
+++ b/core/src/main/java/org/everit/json/schema/ReferenceSchema.java
@@ -22,7 +22,7 @@ import java.util.Objects;
  * during the construction of the schema. This class has been made mutable to permit the loading of
  * recursive schemas.
  */
-public final class ReferenceSchema extends Schema {
+public class ReferenceSchema extends Schema {
 
   /**
    * Builder class for {@link ReferenceSchema}.
@@ -90,16 +90,25 @@ public final class ReferenceSchema extends Schema {
   }
 
   @Override
-  public boolean equals(Object o) {
+  public final boolean equals(Object o) {
     if (this == o) return true;
-    if (o == null || getClass() != o.getClass()) return false;
-    if (!super.equals(o)) return false;
-    ReferenceSchema that = (ReferenceSchema) o;
-    return Objects.equals(referredSchema, that.referredSchema);
+    if (o instanceof ReferenceSchema) {
+      ReferenceSchema that = (ReferenceSchema) o;
+      return that.canEqual(this) &&
+              Objects.equals(referredSchema, that.referredSchema) &&
+              super.equals(that);
+    } else {
+      return false;
+    }
   }
 
   @Override
-  public int hashCode() {
+  public final int hashCode() {
     return Objects.hash(super.hashCode(), referredSchema);
+  }
+
+  @Override
+  protected boolean canEqual(Object other) {
+    return other instanceof ReferenceSchema;
   }
 }

--- a/core/src/main/java/org/everit/json/schema/ReferenceSchema.java
+++ b/core/src/main/java/org/everit/json/schema/ReferenceSchema.java
@@ -90,7 +90,7 @@ public class ReferenceSchema extends Schema {
   }
 
   @Override
-  public final boolean equals(Object o) {
+  public boolean equals(Object o) {
     if (this == o) return true;
     if (o instanceof ReferenceSchema) {
       ReferenceSchema that = (ReferenceSchema) o;
@@ -103,7 +103,7 @@ public class ReferenceSchema extends Schema {
   }
 
   @Override
-  public final int hashCode() {
+  public int hashCode() {
     return Objects.hash(super.hashCode(), referredSchema);
   }
 

--- a/core/src/main/java/org/everit/json/schema/Schema.java
+++ b/core/src/main/java/org/everit/json/schema/Schema.java
@@ -16,6 +16,7 @@
 package org.everit.json.schema;
 
 import javax.annotation.Generated;
+import java.util.Objects;
 
 /**
  * Superclass of all other schema validator classes of this package.
@@ -133,50 +134,22 @@ public abstract class Schema {
   }
 
   @Override
-  public int hashCode() {
-    final int prime = 31;
-    int result = 1;
-    result = prime * result + ((description == null) ? 0 : description.hashCode());
-    result = prime * result + ((id == null) ? 0 : id.hashCode());
-    result = prime * result + ((title == null) ? 0 : title.hashCode());
-    return result;
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o instanceof Schema) {
+      Schema schema = (Schema) o;
+      return schema.canEqual(this) &&
+              Objects.equals(title, schema.title) &&
+              Objects.equals(description, schema.description) &&
+              Objects.equals(id, schema.id);
+    } else {
+      return false;
+    }
   }
 
   @Override
-  @Generated(value = "eclipse")
-  public boolean equals(final Object obj) {
-    if (this == obj) {
-      return true;
-    }
-    if (obj == null) {
-      return false;
-    }
-    if (getClass() != obj.getClass()) {
-      return false;
-    }
-    Schema other = (Schema) obj;
-    if (description == null) {
-      if (other.description != null) {
-        return false;
-      }
-    } else if (!description.equals(other.description)) {
-      return false;
-    }
-    if (id == null) {
-      if (other.id != null) {
-        return false;
-      }
-    } else if (!id.equals(other.id)) {
-      return false;
-    }
-    if (title == null) {
-      if (other.title != null) {
-        return false;
-      }
-    } else if (!title.equals(other.title)) {
-      return false;
-    }
-    return true;
+  public int hashCode() {
+    return Objects.hash(title, description, id);
   }
 
   public String getTitle() {
@@ -191,4 +164,13 @@ public abstract class Schema {
     return id;
   }
 
+  /**
+   * Because we add state in subclasses, but want those subclasses to be non final,
+   * this allows us to have equals methods that satisfy the equals contract.
+   *
+   * http://www.artima.com/lejava/articles/equality.html
+     */
+  protected boolean canEqual(Object other) {
+    return (other instanceof Schema);
+  }
 }

--- a/core/src/main/java/org/everit/json/schema/StringSchema.java
+++ b/core/src/main/java/org/everit/json/schema/StringSchema.java
@@ -175,7 +175,7 @@ public class StringSchema extends Schema {
   }
 
   @Override
-  public final boolean equals(Object o) {
+  public boolean equals(Object o) {
     if (this == o) return true;
     if (o instanceof StringSchema) {
       StringSchema that = (StringSchema) o;
@@ -200,7 +200,7 @@ public class StringSchema extends Schema {
   }
 
   @Override
-  public final int hashCode() {
+  public int hashCode() {
     return Objects.hash(super.hashCode(), minLength, maxLength, pattern, requiresString, formatValidator);
   }
 

--- a/core/src/main/java/org/everit/json/schema/StringSchema.java
+++ b/core/src/main/java/org/everit/json/schema/StringSchema.java
@@ -183,8 +183,16 @@ public final class StringSchema extends Schema {
     return requiresString == that.requiresString &&
             Objects.equals(minLength, that.minLength) &&
             Objects.equals(maxLength, that.maxLength) &&
-            Objects.equals(pattern, that.pattern) &&
+            Objects.equals(patternIfNotNull(pattern), patternIfNotNull(that.pattern)) &&
             Objects.equals(formatValidator, that.formatValidator);
+  }
+
+  private String patternIfNotNull(Pattern pattern) {
+    if (pattern == null) {
+      return null;
+    } else {
+        return pattern.pattern();
+    }
   }
 
   @Override

--- a/core/src/main/java/org/everit/json/schema/StringSchema.java
+++ b/core/src/main/java/org/everit/json/schema/StringSchema.java
@@ -25,7 +25,7 @@ import java.util.regex.Pattern;
 /**
  * {@code String} schema validator.
  */
-public final class StringSchema extends Schema {
+public class StringSchema extends Schema {
 
   /**
    * Builder class for {@link StringSchema}.
@@ -175,16 +175,20 @@ public final class StringSchema extends Schema {
   }
 
   @Override
-  public boolean equals(Object o) {
+  public final boolean equals(Object o) {
     if (this == o) return true;
-    if (o == null || getClass() != o.getClass()) return false;
-    if (!super.equals(o)) return false;
-    StringSchema that = (StringSchema) o;
-    return requiresString == that.requiresString &&
-            Objects.equals(minLength, that.minLength) &&
-            Objects.equals(maxLength, that.maxLength) &&
-            Objects.equals(patternIfNotNull(pattern), patternIfNotNull(that.pattern)) &&
-            Objects.equals(formatValidator, that.formatValidator);
+    if (o instanceof StringSchema) {
+      StringSchema that = (StringSchema) o;
+      return that.canEqual(this) &&
+              requiresString == that.requiresString &&
+              Objects.equals(minLength, that.minLength) &&
+              Objects.equals(maxLength, that.maxLength) &&
+              Objects.equals(patternIfNotNull(pattern), patternIfNotNull(that.pattern)) &&
+              Objects.equals(formatValidator, that.formatValidator) &&
+              super.equals(that);
+    } else {
+      return false;
+    }
   }
 
   private String patternIfNotNull(Pattern pattern) {
@@ -196,7 +200,12 @@ public final class StringSchema extends Schema {
   }
 
   @Override
-  public int hashCode() {
+  public final int hashCode() {
     return Objects.hash(super.hashCode(), minLength, maxLength, pattern, requiresString, formatValidator);
+  }
+
+  @Override
+  protected boolean canEqual(Object other) {
+    return other instanceof StringSchema;
   }
 }

--- a/core/src/main/java/org/everit/json/schema/StringSchema.java
+++ b/core/src/main/java/org/everit/json/schema/StringSchema.java
@@ -25,7 +25,7 @@ import java.util.regex.Pattern;
 /**
  * {@code String} schema validator.
  */
-public class StringSchema extends Schema {
+public final class StringSchema extends Schema {
 
   /**
    * Builder class for {@link StringSchema}.
@@ -174,4 +174,21 @@ public class StringSchema extends Schema {
     }
   }
 
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    if (!super.equals(o)) return false;
+    StringSchema that = (StringSchema) o;
+    return requiresString == that.requiresString &&
+            Objects.equals(minLength, that.minLength) &&
+            Objects.equals(maxLength, that.maxLength) &&
+            Objects.equals(pattern, that.pattern) &&
+            Objects.equals(formatValidator, that.formatValidator);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(super.hashCode(), minLength, maxLength, pattern, requiresString, formatValidator);
+  }
 }

--- a/core/src/test/java/org/everit/json/schema/ArraySchemaTest.java
+++ b/core/src/test/java/org/everit/json/schema/ArraySchemaTest.java
@@ -16,6 +16,7 @@
 package org.everit.json.schema;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
+import nl.jqno.equalsverifier.Warning;
 import org.json.JSONObject;
 import org.json.JSONTokener;
 import org.junit.Test;
@@ -159,6 +160,7 @@ public class ArraySchemaTest {
   public void equalsVerifier() {
       EqualsVerifier.forClass(ArraySchema.class)
               .withRedefinedSuperclass()
+              .suppress(Warning.STRICT_INHERITANCE)
               .verify();
   }
 }

--- a/core/src/test/java/org/everit/json/schema/ArraySchemaTest.java
+++ b/core/src/test/java/org/everit/json/schema/ArraySchemaTest.java
@@ -15,6 +15,7 @@
  */
 package org.everit.json.schema;
 
+import nl.jqno.equalsverifier.EqualsVerifier;
 import org.json.JSONObject;
 import org.json.JSONTokener;
 import org.junit.Test;
@@ -152,5 +153,12 @@ public class ArraySchemaTest {
   public void uniqueObjectValues() {
     ArraySchema.builder().uniqueItems(true).build()
         .validate(ARRAYS.get("uniqueObjectValues"));
+  }
+
+  @Test
+  public void equalsVerifier() {
+      EqualsVerifier.forClass(ArraySchema.class)
+              .withRedefinedSuperclass()
+              .verify();
   }
 }

--- a/core/src/test/java/org/everit/json/schema/BooleanSchemaTest.java
+++ b/core/src/test/java/org/everit/json/schema/BooleanSchemaTest.java
@@ -16,6 +16,7 @@
 package org.everit.json.schema;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
+import nl.jqno.equalsverifier.Warning;
 import org.junit.Test;
 
 public class BooleanSchemaTest {
@@ -37,6 +38,7 @@ public class BooleanSchemaTest {
   public void equalsVerifier() {
     EqualsVerifier.forClass(BooleanSchema.class)
             .withRedefinedSuperclass()
+            .suppress(Warning.STRICT_INHERITANCE)
             .verify();
   }
 }

--- a/core/src/test/java/org/everit/json/schema/BooleanSchemaTest.java
+++ b/core/src/test/java/org/everit/json/schema/BooleanSchemaTest.java
@@ -15,6 +15,7 @@
  */
 package org.everit.json.schema;
 
+import nl.jqno.equalsverifier.EqualsVerifier;
 import org.junit.Test;
 
 public class BooleanSchemaTest {
@@ -30,5 +31,12 @@ public class BooleanSchemaTest {
   @Test
   public void success() {
     BooleanSchema.INSTANCE.validate(true);
+  }
+
+  @Test
+  public void equalsVerifier() {
+    EqualsVerifier.forClass(BooleanSchema.class)
+            .withRedefinedSuperclass()
+            .verify();
   }
 }

--- a/core/src/test/java/org/everit/json/schema/CombinedSchemaTest.java
+++ b/core/src/test/java/org/everit/json/schema/CombinedSchemaTest.java
@@ -19,6 +19,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
+import nl.jqno.equalsverifier.Warning;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -111,6 +112,7 @@ public class CombinedSchemaTest {
   public void equalsVerifier() {
     EqualsVerifier.forClass(CombinedSchema.class)
             .withRedefinedSuperclass()
+            .suppress(Warning.STRICT_INHERITANCE)
             .verify();
   }
 

--- a/core/src/test/java/org/everit/json/schema/CombinedSchemaTest.java
+++ b/core/src/test/java/org/everit/json/schema/CombinedSchemaTest.java
@@ -18,6 +18,7 @@ package org.everit.json.schema;
 import java.util.Arrays;
 import java.util.List;
 
+import nl.jqno.equalsverifier.EqualsVerifier;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -104,6 +105,13 @@ public class CombinedSchemaTest {
     } catch (ValidationException e) {
       Assert.assertEquals(1, e.getCausingExceptions().size());
     }
+  }
+
+  @Test
+  public void equalsVerifier() {
+    EqualsVerifier.forClass(CombinedSchema.class)
+            .withRedefinedSuperclass()
+            .verify();
   }
 
 }

--- a/core/src/test/java/org/everit/json/schema/EmptySchemaTest.java
+++ b/core/src/test/java/org/everit/json/schema/EmptySchemaTest.java
@@ -1,6 +1,7 @@
 package org.everit.json.schema;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
+import nl.jqno.equalsverifier.Warning;
 import org.junit.Test;
 
 public class EmptySchemaTest {
@@ -9,6 +10,7 @@ public class EmptySchemaTest {
     public void equalsVerifier() {
         EqualsVerifier.forClass(EmptySchema.class)
                 .withRedefinedSuperclass()
+                .suppress(Warning.STRICT_INHERITANCE)
                 .verify();
     }
 }

--- a/core/src/test/java/org/everit/json/schema/EmptySchemaTest.java
+++ b/core/src/test/java/org/everit/json/schema/EmptySchemaTest.java
@@ -1,0 +1,14 @@
+package org.everit.json.schema;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+import org.junit.Test;
+
+public class EmptySchemaTest {
+
+    @Test
+    public void equalsVerifier() {
+        EqualsVerifier.forClass(EmptySchema.class)
+                .withRedefinedSuperclass()
+                .verify();
+    }
+}

--- a/core/src/test/java/org/everit/json/schema/EnumSchemaTest.java
+++ b/core/src/test/java/org/everit/json/schema/EnumSchemaTest.java
@@ -19,6 +19,7 @@ import java.util.HashSet;
 import java.util.Set;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
+import nl.jqno.equalsverifier.Warning;
 import org.json.JSONArray;
 import org.json.JSONObject;
 import org.junit.Before;
@@ -63,6 +64,7 @@ public class EnumSchemaTest {
   public void equalsVerifier() {
     EqualsVerifier.forClass(EnumSchema.class)
             .withRedefinedSuperclass()
+            .suppress(Warning.STRICT_INHERITANCE)
             .verify();
   }
 

--- a/core/src/test/java/org/everit/json/schema/EnumSchemaTest.java
+++ b/core/src/test/java/org/everit/json/schema/EnumSchemaTest.java
@@ -18,6 +18,7 @@ package org.everit.json.schema;
 import java.util.HashSet;
 import java.util.Set;
 
+import nl.jqno.equalsverifier.EqualsVerifier;
 import org.json.JSONArray;
 import org.json.JSONObject;
 import org.junit.Before;
@@ -56,6 +57,13 @@ public class EnumSchemaTest {
     subject.validate("foo");
     subject.validate(new JSONArray());
     subject.validate(new JSONObject("{\"a\" : 0}"));
+  }
+
+  @Test
+  public void equalsVerifier() {
+    EqualsVerifier.forClass(EnumSchema.class)
+            .withRedefinedSuperclass()
+            .verify();
   }
 
 }

--- a/core/src/test/java/org/everit/json/schema/NotSchemaTest.java
+++ b/core/src/test/java/org/everit/json/schema/NotSchemaTest.java
@@ -15,6 +15,7 @@
  */
 package org.everit.json.schema;
 
+import nl.jqno.equalsverifier.EqualsVerifier;
 import org.junit.Test;
 
 public class NotSchemaTest {
@@ -33,4 +34,10 @@ public class NotSchemaTest {
     NotSchema.builder().mustNotMatch(BooleanSchema.INSTANCE).build().validate("foo");
   }
 
+  @Test
+  public void equalsVerifier() {
+    EqualsVerifier.forClass(NotSchema.class)
+            .withRedefinedSuperclass()
+            .verify();
+  }
 }

--- a/core/src/test/java/org/everit/json/schema/NotSchemaTest.java
+++ b/core/src/test/java/org/everit/json/schema/NotSchemaTest.java
@@ -16,6 +16,7 @@
 package org.everit.json.schema;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
+import nl.jqno.equalsverifier.Warning;
 import org.junit.Test;
 
 public class NotSchemaTest {
@@ -38,6 +39,7 @@ public class NotSchemaTest {
   public void equalsVerifier() {
     EqualsVerifier.forClass(NotSchema.class)
             .withRedefinedSuperclass()
+            .suppress(Warning.STRICT_INHERITANCE)
             .verify();
   }
 }

--- a/core/src/test/java/org/everit/json/schema/NullSchemaTest.java
+++ b/core/src/test/java/org/everit/json/schema/NullSchemaTest.java
@@ -16,6 +16,7 @@
 package org.everit.json.schema;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
+import nl.jqno.equalsverifier.Warning;
 import org.json.JSONObject;
 import org.junit.Test;
 
@@ -39,6 +40,7 @@ public class NullSchemaTest {
   public void equalsVerifier() {
     EqualsVerifier.forClass(NullSchema.class)
             .withRedefinedSuperclass()
+            .suppress(Warning.STRICT_INHERITANCE)
             .verify();
   }
 }

--- a/core/src/test/java/org/everit/json/schema/NullSchemaTest.java
+++ b/core/src/test/java/org/everit/json/schema/NullSchemaTest.java
@@ -15,6 +15,7 @@
  */
 package org.everit.json.schema;
 
+import nl.jqno.equalsverifier.EqualsVerifier;
 import org.json.JSONObject;
 import org.junit.Test;
 
@@ -32,5 +33,12 @@ public class NullSchemaTest {
   public void success() {
     JSONObject obj = new JSONObject("{\"a\" : null}");
     NullSchema.INSTANCE.validate(obj.get("a"));
+  }
+
+  @Test
+  public void equalsVerifier() {
+    EqualsVerifier.forClass(NullSchema.class)
+            .withRedefinedSuperclass()
+            .verify();
   }
 }

--- a/core/src/test/java/org/everit/json/schema/NumberSchemaTest.java
+++ b/core/src/test/java/org/everit/json/schema/NumberSchemaTest.java
@@ -15,6 +15,7 @@
  */
 package org.everit.json.schema;
 
+import nl.jqno.equalsverifier.EqualsVerifier;
 import org.junit.Test;
 
 public class NumberSchemaTest {
@@ -110,4 +111,10 @@ public class NumberSchemaTest {
     NumberSchema.builder().requiresInteger(true).build().validate(Long.valueOf(4278190207L));
   }
 
+  @Test
+  public void equalsVerifier() {
+    EqualsVerifier.forClass(NumberSchema.class)
+            .withRedefinedSuperclass()
+            .verify();
+  }
 }

--- a/core/src/test/java/org/everit/json/schema/NumberSchemaTest.java
+++ b/core/src/test/java/org/everit/json/schema/NumberSchemaTest.java
@@ -16,6 +16,7 @@
 package org.everit.json.schema;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
+import nl.jqno.equalsverifier.Warning;
 import org.junit.Test;
 
 public class NumberSchemaTest {
@@ -115,6 +116,7 @@ public class NumberSchemaTest {
   public void equalsVerifier() {
     EqualsVerifier.forClass(NumberSchema.class)
             .withRedefinedSuperclass()
+            .suppress(Warning.STRICT_INHERITANCE)
             .verify();
   }
 }

--- a/core/src/test/java/org/everit/json/schema/ObjectSchemaTest.java
+++ b/core/src/test/java/org/everit/json/schema/ObjectSchemaTest.java
@@ -16,6 +16,7 @@
 package org.everit.json.schema;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
+import nl.jqno.equalsverifier.Warning;
 import org.json.JSONObject;
 import org.json.JSONTokener;
 import org.junit.Assert;
@@ -274,6 +275,7 @@ public class ObjectSchemaTest {
   public void equalsVerifier() {
     EqualsVerifier.forClass(ObjectSchema.class)
             .withRedefinedSuperclass()
+            .suppress(Warning.STRICT_INHERITANCE)
             .verify();
   }
 }

--- a/core/src/test/java/org/everit/json/schema/ObjectSchemaTest.java
+++ b/core/src/test/java/org/everit/json/schema/ObjectSchemaTest.java
@@ -15,6 +15,7 @@
  */
 package org.everit.json.schema;
 
+import nl.jqno.equalsverifier.EqualsVerifier;
 import org.json.JSONObject;
 import org.json.JSONTokener;
 import org.junit.Assert;
@@ -267,5 +268,12 @@ public class ObjectSchemaTest {
         .expectedKeyword("type")
         .input("a")
         .expect();
+  }
+
+  @Test
+  public void equalsVerifier() {
+    EqualsVerifier.forClass(ObjectSchema.class)
+            .withRedefinedSuperclass()
+            .verify();
   }
 }

--- a/core/src/test/java/org/everit/json/schema/ReferenceSchemaTest.java
+++ b/core/src/test/java/org/everit/json/schema/ReferenceSchemaTest.java
@@ -15,6 +15,8 @@
  */
 package org.everit.json.schema;
 
+import nl.jqno.equalsverifier.EqualsVerifier;
+import nl.jqno.equalsverifier.Warning;
 import org.everit.json.schema.BooleanSchema;
 import org.everit.json.schema.ReferenceSchema;
 import org.everit.json.schema.ReferenceSchema.Builder;
@@ -36,4 +38,12 @@ public class ReferenceSchemaTest {
     subject.setReferredSchema(BooleanSchema.INSTANCE);
   }
 
+  @Test
+  public void equalsVerifier() {
+    EqualsVerifier.forClass(ReferenceSchema.class)
+            .withRedefinedSuperclass()
+            //there are specifically some non final fields for loading of recursive schemas
+            .suppress(Warning.NONFINAL_FIELDS)
+            .verify();
+  }
 }

--- a/core/src/test/java/org/everit/json/schema/ReferenceSchemaTest.java
+++ b/core/src/test/java/org/everit/json/schema/ReferenceSchemaTest.java
@@ -44,6 +44,7 @@ public class ReferenceSchemaTest {
             .withRedefinedSuperclass()
             //there are specifically some non final fields for loading of recursive schemas
             .suppress(Warning.NONFINAL_FIELDS)
+            .suppress(Warning.STRICT_INHERITANCE)
             .verify();
   }
 }

--- a/core/src/test/java/org/everit/json/schema/StringSchemaTest.java
+++ b/core/src/test/java/org/everit/json/schema/StringSchemaTest.java
@@ -17,6 +17,7 @@ package org.everit.json.schema;
 
 import java.util.Optional;
 
+import nl.jqno.equalsverifier.EqualsVerifier;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -99,5 +100,12 @@ public class StringSchemaTest {
   @Test(expected = ValidationException.class)
   public void issue38Pattern() {
     StringSchema.builder().requiresString(true).pattern("\\+?\\d+").build().validate("aaa");
+  }
+
+  @Test
+  public void equalsVerifier() {
+    EqualsVerifier.forClass(StringSchema.class)
+            .withRedefinedSuperclass()
+            .verify();
   }
 }

--- a/core/src/test/java/org/everit/json/schema/StringSchemaTest.java
+++ b/core/src/test/java/org/everit/json/schema/StringSchemaTest.java
@@ -18,6 +18,7 @@ package org.everit.json.schema;
 import java.util.Optional;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
+import nl.jqno.equalsverifier.Warning;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -106,6 +107,7 @@ public class StringSchemaTest {
   public void equalsVerifier() {
     EqualsVerifier.forClass(StringSchema.class)
             .withRedefinedSuperclass()
+            .suppress(Warning.STRICT_INHERITANCE)
             .verify();
   }
 }


### PR DESCRIPTION
This makes the derived schema classes final. This could break backward compatibility. If needed, that can be relaxed.

fixes #49 
