### PR TITLE
Add ValidationException#getAllMessages() for collecting nested error messages

### DIFF
--- a/core/src/test/java/org/everit/json/schema/ObjectSchemaTest.java
+++ b/core/src/test/java/org/everit/json/schema/ObjectSchemaTest.java
@@ -22,6 +22,7 @@ import org.json.JSONObject;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.util.List;
 import java.util.concurrent.Callable;
 
 import static org.junit.Assert.assertTrue;
@@ -136,9 +137,15 @@ public class ObjectSchemaTest {
             Assert.fail("did not throw exception for 3 schema violations");
         } catch (ValidationException e) {
             Assert.assertEquals(3, e.getCausingExceptions().size());
-            Assert.assertEquals(1, TestSupport.countCauseByJsonPointer(e, "#/numberProp"));
             Assert.assertEquals(1, TestSupport.countCauseByJsonPointer(e, "#"));
+            Assert.assertEquals(1, TestSupport.countCauseByJsonPointer(e, "#/numberProp"));
             Assert.assertEquals(1, TestSupport.countCauseByJsonPointer(e, "#/stringPatternMatch"));
+
+            List<String> messages = e.getAllMessages();
+            Assert.assertEquals(3, messages.size());
+            Assert.assertEquals(1, TestSupport.countMatchingMessage(messages, "#:"));
+            Assert.assertEquals(1, TestSupport.countMatchingMessage(messages, "#/numberProp:"));
+            Assert.assertEquals(1, TestSupport.countMatchingMessage(messages, "#/stringPatternMatch:"));
         }
     }
 
@@ -186,6 +193,18 @@ public class ObjectSchemaTest {
             Assert.assertEquals(1, TestSupport.countCauseByJsonPointer(nested2Exception, "#/nested/nested"));
             Assert.assertEquals(1, TestSupport.countCauseByJsonPointer(nested2Exception, "#/nested/nested/numberProp"));
             Assert.assertEquals(1, TestSupport.countCauseByJsonPointer(nested2Exception, "#/nested/nested/stringPatternMatch"));
+
+            List<String> messages = subjectException.getAllMessages();
+            Assert.assertEquals(9, messages.size());
+            Assert.assertEquals(1, TestSupport.countMatchingMessage(messages, "#:"));
+            Assert.assertEquals(1, TestSupport.countMatchingMessage(messages, "#/numberProp:"));
+            Assert.assertEquals(1, TestSupport.countMatchingMessage(messages, "#/stringPatternMatch:"));
+            Assert.assertEquals(1, TestSupport.countMatchingMessage(messages, "#/nested:"));
+            Assert.assertEquals(1, TestSupport.countMatchingMessage(messages, "#/nested/numberProp:"));
+            Assert.assertEquals(1, TestSupport.countMatchingMessage(messages, "#/nested/stringPatternMatch:"));
+            Assert.assertEquals(1, TestSupport.countMatchingMessage(messages, "#/nested/nested:"));
+            Assert.assertEquals(1, TestSupport.countMatchingMessage(messages, "#/nested/nested/numberProp:"));
+            Assert.assertEquals(1, TestSupport.countMatchingMessage(messages, "#/nested/nested/stringPatternMatch:"));
         }
     }
 

--- a/core/src/test/java/org/everit/json/schema/TestSupport.java
+++ b/core/src/test/java/org/everit/json/schema/TestSupport.java
@@ -17,6 +17,8 @@ package org.everit.json.schema;
 
 import org.junit.Assert;
 
+import java.util.List;
+
 public class TestSupport {
 
     public static class Failure {
@@ -92,6 +94,12 @@ public class TestSupport {
         return root.getCausingExceptions().stream()
                 .map(ValidationException::getPointerToViolation)
                 .filter(ptr -> ptr.equals(pointer))
+                .count();
+    }
+
+    public static long countMatchingMessage(final List<String> messages, final String expectedSubstring) {
+        return messages.stream()
+                .filter(message -> message.contains(expectedSubstring))
                 .count();
     }
 

--- a/core/src/test/resources/org/everit/jsonvalidator/objecttestcases.json
+++ b/core/src/test/resources/org/everit/jsonvalidator/objecttestcases.json
@@ -40,6 +40,18 @@
     "numberProp": "not number",
     "stringPatternMatch": 2
   },
+  "multipleViolationsNested": {
+    "numberProp": "not number",
+    "stringPatternMatch": 2,
+    "nested": {
+      "numberProp": "not number 1",
+      "stringPatternMatch": 11,
+      "nested": {
+        "numberProp": "not number 2",
+        "stringPatternMatch": 22
+      }
+    }
+  },
   "rectangleSingleFailure": {
     "rectangle": {
       "a": -5,


### PR DESCRIPTION
`ValidationException#getAllMessages()` walks through all nested violations and return the list of error messages. This is particularly useful for use by a REST API when validating the schema of an incoming JSON payload. The flat list of messages provides a convenient format for clients to log, and even parse, the errors.

I also added a unit test to verify existing and new behavior for multiple nested schema violations.