### PR TITLE
Fix unicode length comparisons

### DIFF
--- a/core/src/main/java/org/everit/json/schema/StringSchema.java
+++ b/core/src/main/java/org/everit/json/schema/StringSchema.java
@@ -131,7 +131,7 @@ public class StringSchema extends Schema {
     }
 
     private List<ValidationException> testLength(final String subject) {
-        int actualLength = subject.length();
+        int actualLength = subject.codePointCount(0, subject.length());
         List<ValidationException> rval = new ArrayList<>();
         if (minLength != null && actualLength < minLength.intValue()) {
             rval.add(new ValidationException(this, "expected minLength: " + minLength + ", actual: "

--- a/tests/src/test/resources/org/everit/json/schema/draft4/maxLength.json
+++ b/tests/src/test/resources/org/everit/json/schema/draft4/maxLength.json
@@ -28,7 +28,7 @@
       {
         "description": "two supplementary Unicode code points is long enough",
         "data": "\uD83D\uDCA9\uD83D\uDCA9",
-        "valid": false
+        "valid": true
       }
     ]
   }

--- a/tests/src/test/resources/org/everit/json/schema/draft4/minLength.json
+++ b/tests/src/test/resources/org/everit/json/schema/draft4/minLength.json
@@ -28,7 +28,7 @@
       {
         "description": "one supplementary Unicode code point is not long enough",
         "data": "\uD83D\uDCA9",
-        "valid": true
+        "valid": false
       }
     ]
   }


### PR DESCRIPTION
The test suite had the wrong expected values for max/minLength for unicode strings, they've been updated. See: [draft4/minLength.json#29](https://github.com/json-schema-org/JSON-Schema-Test-Suite/blob/develop/tests/draft4/minLength.json#L29) and [draft4/maxLength#29](https://github.com/json-schema-org/JSON-Schema-Test-Suite/blob/develop/tests/draft4/maxLength.json#L29)


Use the number of unicode codepoints to compare lengths.  see: [stackoverflow](http://stackoverflow.com/questions/6828076/how-to-correctly-compute-the-length-of-a-string-in-java)


Why was the test suite logic flipped? Old data? Perhaps looking into importing the test suite as git submodule would be a good idea?
