### PR TITLE
missing version for `org.apache.felix:maven-bundle-plugin`

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -57,6 +57,7 @@
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
+                <version>3.2.0</version>
                 <extensions>true</extensions>
                 <configuration>
                     <instructions>


### PR DESCRIPTION
```
$ mvn clean
[INFO] Scanning for projects...
[WARNING]
[WARNING] Some problems were encountered while building the effective model for org.everit.json:org.everit.json.schema:bundle:1.4.1
[WARNING] 'build.plugins.plugin.version' fororg.apache.felix:maven-bundle-plugin is missing. @ line 57, column 21
[WARNING]
[WARNING] It is highly recommended to fix these problems because theythreaten the stability of your build.
[WARNING]
[WARNING] For this reason, future Maven versions might no longer support building such malformed projects.
[WARNING]
```

The (sub) module `core` did not reference the parent POM thus the version from the (transitive) parent `org.everit.config:org.everit.config.main` is not available. The version used is `3.0.0`.

Apply quick fix by adding mandatory `<version/>`. The current version is `3.2.0` since Sep 27, 2016.