### PR TITLE
enable code coverage reporting on Coveralls.io

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: java
 jdk:
     - oraclejdk8
 script: mvn verify
+after_success:
+    - mvn -f core/pom.xml jacoco:report coveralls:report
 install: true
 sudo: false
 cache:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # JSON Schema Validator
 
-[![Apache 2.0 License][ASL 2.0 badge]][ASL 2.0] [![Build Status][Travis badge master]][Travis]
+[![Apache 2.0 License][ASL 2.0 badge]][ASL 2.0] [![Build Status][Travis badge master]][Travis] [![Coverage Status][Coveralls.io badge master]][Coveralls.io]
 
 * [When to use this library?](#when-to-use-this-library)
 * [Maven installation](#maven-installation)
@@ -233,6 +233,8 @@ SchemaLoader schemaLoader = SchemaLoader.builder()
 [ASL 2.0]: https://www.apache.org/licenses/LICENSE-2.0
 [Travis badge master]: https://travis-ci.org/everit-org/json-schema.svg?branch=master
 [Travis]: https://travis-ci.org/everit-org/json-schema
+[Coveralls.io badge master]: https://coveralls.io/repos/github/everit-org/json-schema/badge.svg?branch=master
+[Coveralls.io]: https://coveralls.io/github/everit-org/json-schema?branch=master
 [daveclayton/json-schema-validator]: https://github.com/daveclayton/json-schema-validator
 [draft-zyp-json-schema-04]: https://tools.ietf.org/html/draft-zyp-json-schema-04
 [draft-fge-json-schema-validation-00 format]: https://tools.ietf.org/html/draft-fge-json-schema-validation-00#section-7

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -27,6 +27,7 @@
         <projectpath>json-schema</projectpath>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
+        <jacoco.version>0.7.8</jacoco.version>
     </properties>
     <name>everit-org/json-schema</name>
     <url>https://github.com/everit-org/json-schema</url>
@@ -69,6 +70,30 @@
                             ${project.artifactId}.loader;version=${project.version}
                         </Export-Package>
                     </instructions>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>${jacoco.version}</version>
+                <executions>
+                    <execution>
+                        <id>default-prepare-agent</id>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                        <configuration>
+                            <propertyName>surefireArgLine</propertyName>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <groupId>org.apache.maven.plugins</groupId>
+                <version>2.19.1</version>
+                <configuration>
+                    <argLine>${surefireArgLine}</argLine>
                 </configuration>
             </plugin>
         </plugins>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -24,6 +24,8 @@
     <version>1.4.1</version>
     <packaging>bundle</packaging>
     <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <projectpath>json-schema</projectpath>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
@@ -95,6 +97,11 @@
                 <configuration>
                     <argLine>${surefireArgLine}</argLine>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.eluder.coveralls</groupId>
+                <artifactId>coveralls-maven-plugin</artifactId>
+                <version>4.3.0</version>
             </plugin>
         </plugins>
     </build>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -104,7 +104,7 @@
         <dependency>
             <groupId>nl.jqno.equalsverifier</groupId>
             <artifactId>equalsverifier</artifactId>
-            <version>2.1.6</version>
+            <version>2.1.8</version>
             <scope>test</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
As discussed/proposed in #69 enable code coverage reporting on [Coveralls.io](https://coveralls.io).

@erosb before you accept this PR you can [have a look](https://coveralls.io/github/agebhar1/json-schema) how it will be. Sign in with your GitHub account on [Coveralls.io](https://coveralls.io) and enable this repository - maybe you must (re)sync with GitHub if it does not appear on the site. The configuration for Travis CI is updated and the badge for code coverage on `master` branch is also added.

Congrats for this code coverage!