### PR TITLE
update »Apache Commons Validator« to 1.6

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -152,7 +152,7 @@
         <dependency>
             <groupId>commons-validator</groupId>
             <artifactId>commons-validator</artifactId>
-            <version>1.5.1</version>
+            <version>1.6</version>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>


### PR DESCRIPTION
Update to latest version 1.6 [1].

[1] https://commons.apache.org/proper/commons-validator/changes-report.html#a1.6