### PR TITLE
Updating Maven information based on jitpack.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,9 +38,9 @@ Add the JitPack repository and the dependency to your `pom.xml` as follows:
 
 ```xml
 <dependency>
-    <groupId>com.github.everit-org.json-schema</groupId>
-    <artifactId>org.everit.json.schema</artifactId>
-    <version>1.6.0</version>
+   <groupId>com.github.everit-org</groupId>
+   <artifactId>json-schema</artifactId>
+   <version>1.6.0</version>
 </dependency>
 ...
 <repositories>


### PR DESCRIPTION
Based on this https://jitpack.io/#everit-org/json-schema/1.6.0 I've updated the Maven link to reflect what appears to be the correct