### PR TITLE
Fixing #116, 'not' in strings.

### DIFF
--- a/core/src/main/java/org/everit/json/schema/loader/JsonObject.java
+++ b/core/src/main/java/org/everit/json/schema/loader/JsonObject.java
@@ -16,11 +16,11 @@ import org.everit.json.schema.SchemaException;
 /**
  * @author erosb
  */
-final class JsonObject extends JsonValue {
+public final class JsonObject extends JsonValue {
 
     private final Map<String, Object> storage;
 
-    JsonObject(Map<String, Object> storage) {
+    public JsonObject(Map<String, Object> storage) {
         super(storage);
         this.storage = storage;
     }
@@ -100,7 +100,7 @@ final class JsonObject extends JsonValue {
         return new HashMap<>(storage);
     }
 
-    Map<String, Object> toMap() {
+    public Map<String, Object> toMap() {
         if (storage == null) {
             return null;
         }

--- a/core/src/main/java/org/everit/json/schema/loader/StringSchemaLoader.java
+++ b/core/src/main/java/org/everit/json/schema/loader/StringSchemaLoader.java
@@ -40,6 +40,7 @@ public class StringSchemaLoader {
         ls.schemaJson().maybe("pattern").map(JsonValue::requireString).ifPresent(builder::pattern);
         ls.schemaJson().maybe("format").map(JsonValue::requireString)
                 .ifPresent(format -> addFormatValidator(builder, format));
+        ls.schemaJson().maybe("not").map(JsonValue::requireObject).ifPresent(builder::notSchema);
         return builder;
     }
 

--- a/core/src/test/resources/org/everit/jsonvalidator/not-enum-schema.json
+++ b/core/src/test/resources/org/everit/jsonvalidator/not-enum-schema.json
@@ -1,0 +1,18 @@
+{
+  "type": "object",
+  "properties": {
+    "name": {
+      "type": "string",
+      "not": {
+        "enum": [
+          "A",
+          "B",
+          "C"
+        ]
+      }
+    }
+  },
+  "required": [
+    "name"
+  ]
+}

--- a/core/src/test/resources/org/everit/jsonvalidator/not-hexpattern-schema.json
+++ b/core/src/test/resources/org/everit/jsonvalidator/not-hexpattern-schema.json
@@ -1,0 +1,15 @@
+{
+  "type": "object",
+  "properties": {
+    "name": {
+      "type": "string",
+      "not": {
+        "type" : "string",
+        "pattern" : "^([0-9a-fA-F][0-9a-fA-F])+$"
+      }
+    }
+  },
+  "required": [
+    "name"
+  ]
+}


### PR DESCRIPTION
This fix will clear the issue that I got when using "not" blocks for validation of string.
    
Example would be to add forbidden values (not enum) or anti-patterns (not pattern).

Implementation should be quite straight forwards, and be implementing "not" as a complete schema of its own - using the existing "NotSchema" class to validate the schema.