### PR TITLE
Nullable support

### DIFF
--- a/core/src/main/java/org/everit/json/schema/ArraySchemaValidatingVisitor.java
+++ b/core/src/main/java/org/everit/json/schema/ArraySchemaValidatingVisitor.java
@@ -30,11 +30,7 @@ class ArraySchemaValidatingVisitor extends Visitor {
     }
 
     @Override void visitArraySchema(ArraySchema arraySchema) {
-        if (!(subject instanceof JSONArray)) {
-            if (arraySchema.requiresArray()) {
-                owner.failure(JSONArray.class, subject);
-            }
-        } else {
+        if (owner.passesTypeCheck(JSONArray.class, arraySchema.requiresArray(), arraySchema.isNullable())) {
             this.arraySubject = (JSONArray) subject;
             this.subjectLength = arraySubject.length();
             this.arraySchema = arraySchema;

--- a/core/src/main/java/org/everit/json/schema/ObjectSchemaValidatingVisitor.java
+++ b/core/src/main/java/org/everit/json/schema/ObjectSchemaValidatingVisitor.java
@@ -28,11 +28,7 @@ class ObjectSchemaValidatingVisitor extends Visitor {
     }
 
     @Override void visitObjectSchema(ObjectSchema objectSchema) {
-        if (!(subject instanceof JSONObject)) {
-            if (objectSchema.requiresObject()) {
-                owner.failure(JSONObject.class, subject);
-            }
-        } else {
+        if (owner.passesTypeCheck(JSONObject.class, objectSchema.requiresObject(), objectSchema.isNullable())) {
             objSubject = (JSONObject) subject;
             objectSize = objSubject.length();
             this.schema = objectSchema;

--- a/core/src/main/java/org/everit/json/schema/Schema.java
+++ b/core/src/main/java/org/everit/json/schema/Schema.java
@@ -164,7 +164,8 @@ public abstract class Schema {
                     Objects.equals(title, schema.title) &&
                     Objects.equals(defaultValue, schema.defaultValue) &&
                     Objects.equals(description, schema.description) &&
-                    Objects.equals(id, schema.id);
+                    Objects.equals(id, schema.id) &&
+                    Objects.equals(nullable, schema.nullable);
         } else {
             return false;
         }
@@ -172,7 +173,7 @@ public abstract class Schema {
 
     @Override
     public int hashCode() {
-        return Objects.hash(title, description, id, defaultValue);
+        return Objects.hash(title, description, id, defaultValue, nullable);
     }
 
     public String getTitle() {

--- a/core/src/main/java/org/everit/json/schema/Schema.java
+++ b/core/src/main/java/org/everit/json/schema/Schema.java
@@ -31,6 +31,8 @@ public abstract class Schema {
 
         private Object defaultValue;
 
+        private Boolean nullable = null;
+
         public Builder<S> title(String title) {
             this.title = title;
             return this;
@@ -56,10 +58,15 @@ public abstract class Schema {
             return this;
         }
 
+        public Builder<S> nullable(Boolean nullable) {
+            this.nullable = nullable;
+            return this;
+        }
+
         public abstract S build();
 
-    }
 
+    }
     private final String title;
 
     private final String description;
@@ -69,6 +76,8 @@ public abstract class Schema {
     protected final String schemaLocation;
 
     private final Object defaultValue;
+
+    private final Boolean nullable;
 
     /**
      * Constructor.
@@ -82,6 +91,7 @@ public abstract class Schema {
         this.id = builder.id;
         this.schemaLocation = builder.schemaLocation;
         this.defaultValue = builder.defaultValue;
+        this.nullable = builder.nullable;
     }
 
     /**
@@ -189,6 +199,9 @@ public abstract class Schema {
         return this.defaultValue != null;
     }
 
+    public Boolean isNullable() {
+        return nullable;
+    }
     /**
      * Describes the instance as a JSONObject to {@code writer}.
      * <p>

--- a/core/src/main/java/org/everit/json/schema/Schema.java
+++ b/core/src/main/java/org/everit/json/schema/Schema.java
@@ -220,6 +220,7 @@ public abstract class Schema {
         writer.ifPresent("description", description);
         writer.ifPresent("id", id);
         writer.ifPresent("default", defaultValue);
+        writer.ifPresent("nullable", nullable);
         describePropertiesTo(writer);
         writer.endObject();
     }

--- a/core/src/main/java/org/everit/json/schema/StringSchemaValidatingVisitor.java
+++ b/core/src/main/java/org/everit/json/schema/StringSchemaValidatingVisitor.java
@@ -61,4 +61,5 @@ public class StringSchemaValidatingVisitor extends Visitor {
             failureReporter.failure(failure.get(), "format");
         }
     }
+
 }

--- a/core/src/main/java/org/everit/json/schema/ValidatingVisitor.java
+++ b/core/src/main/java/org/everit/json/schema/ValidatingVisitor.java
@@ -100,7 +100,7 @@ class ValidatingVisitor extends Visitor {
     }
 
     @Override void visitStringSchema(StringSchema stringSchema) {
-        stringSchema.accept(new StringSchemaValidatingVisitor(subject, failureReporter));
+        stringSchema.accept(new StringSchemaValidatingVisitor(subject, this));
     }
 
     @Override void visitCombinedSchema(CombinedSchema combinedSchema) {

--- a/core/src/main/java/org/everit/json/schema/ValidatingVisitor.java
+++ b/core/src/main/java/org/everit/json/schema/ValidatingVisitor.java
@@ -33,7 +33,7 @@ class ValidatingVisitor extends Visitor {
     }
 
     @Override void visitNumberSchema(NumberSchema numberSchema) {
-        numberSchema.accept(new NumberSchemaValidatingVisitor(subject, failureReporter));
+        numberSchema.accept(new NumberSchemaValidatingVisitor(subject, this));
     }
 
     @Override void visitArraySchema(ArraySchema arraySchema) {

--- a/core/src/main/java/org/everit/json/schema/ValidatingVisitor.java
+++ b/core/src/main/java/org/everit/json/schema/ValidatingVisitor.java
@@ -24,6 +24,14 @@ class ValidatingVisitor extends Visitor {
         this.failureReporter = new CollectingFailureReporter(schema);
     }
 
+    @Override
+    void visit(Schema schema) {
+        if (schema.isNullable() == Boolean.FALSE && isNull(subject)) {
+            failureReporter.failure("value cannot be null", "nullable");
+        }
+        super.visit(schema);
+    }
+
     ValidatingVisitor(Object subject, ValidationFailureReporter failureReporter) {
         this.subject = subject;
         this.failureReporter = failureReporter;

--- a/core/src/main/java/org/everit/json/schema/ValidatingVisitor.java
+++ b/core/src/main/java/org/everit/json/schema/ValidatingVisitor.java
@@ -19,11 +19,6 @@ class ValidatingVisitor extends Visitor {
 
     private ValidationFailureReporter failureReporter;
 
-    ValidatingVisitor(Schema schema, Object subject) {
-        this.subject = subject;
-        this.failureReporter = new CollectingFailureReporter(schema);
-    }
-
     @Override
     void visit(Schema schema) {
         if (schema.isNullable() == Boolean.FALSE && isNull(subject)) {
@@ -156,4 +151,19 @@ class ValidatingVisitor extends Visitor {
         failureReporter.failure(exc);
     }
 
+    boolean passesTypeCheck(Class<?> expectedType, boolean schemaRequiresType, Boolean nullable) {
+        if (isNull(subject)) {
+            if (schemaRequiresType && nullable != Boolean.TRUE) {
+                failureReporter.failure(expectedType, subject);
+            }
+            return false;
+        }
+        if (expectedType.isAssignableFrom(subject.getClass())) {
+            return true;
+        }
+        if (schemaRequiresType) {
+            failureReporter.failure(expectedType, subject);
+        }
+        return false;
+    }
 }

--- a/core/src/main/java/org/everit/json/schema/loader/LoaderConfig.java
+++ b/core/src/main/java/org/everit/json/schema/loader/LoaderConfig.java
@@ -25,12 +25,20 @@ class LoaderConfig {
 
     final boolean useDefaults;
 
+    final boolean nullableSupport;
+
     LoaderConfig(SchemaClient httpClient, Map<String, FormatValidator> formatValidators,
             SpecificationVersion specVersion, boolean useDefaults) {
+        this(httpClient, formatValidators, specVersion, useDefaults, false);
+    }
+
+    LoaderConfig(SchemaClient httpClient, Map<String, FormatValidator> formatValidators,
+            SpecificationVersion specVersion, boolean useDefaults, boolean nullableSupport) {
         this.httpClient = requireNonNull(httpClient, "httpClient cannot be null");
         this.formatValidators = requireNonNull(formatValidators, "formatValidators cannot be null");
         this.specVersion = requireNonNull(specVersion, "specVersion cannot be null");
         this.useDefaults = useDefaults;
+        this.nullableSupport = nullableSupport;
     }
 
 }

--- a/core/src/main/java/org/everit/json/schema/loader/SchemaLoader.java
+++ b/core/src/main/java/org/everit/json/schema/loader/SchemaLoader.java
@@ -71,6 +71,8 @@ public class SchemaLoader {
 
         boolean useDefaults = false;
 
+        private boolean nullableSupport = false;
+
         /**
          * Registers a format validator with the name returned by {@link FormatValidator#formatName()}.
          *
@@ -188,6 +190,10 @@ public class SchemaLoader {
             return this;
         }
 
+        public SchemaLoaderBuilder nullableSupport(boolean nullableSupport) {
+            this.nullableSupport = nullableSupport;
+            return this;
+        }
     }
 
     private static final List<String> NUMBER_SCHEMA_PROPS = asList("minimum", "maximum",
@@ -266,7 +272,11 @@ public class SchemaLoader {
                 specVersion = SpecificationVersion.getByMetaSchemaUrl((String) schemaValue);
             }
         }
-        this.config = new LoaderConfig(builder.httpClient, builder.formatValidators, specVersion, builder.useDefaults);
+        this.config = new LoaderConfig(builder.httpClient,
+                builder.formatValidators,
+                specVersion,
+                builder.useDefaults,
+                builder.nullableSupport);
         this.ls = new LoadingState(config,
                 builder.pointerSchemas,
                 builder.rootSchemaJson == null ? builder.schemaJson : builder.rootSchemaJson,
@@ -362,6 +372,9 @@ public class SchemaLoader {
         ls.schemaJson().maybe(config.specVersion.idKeyword()).map(JsonValue::requireString).ifPresent(builder::id);
         ls.schemaJson().maybe("title").map(JsonValue::requireString).ifPresent(builder::title);
         ls.schemaJson().maybe("description").map(JsonValue::requireString).ifPresent(builder::description);
+        if (config.nullableSupport) {
+            ls.schemaJson().maybe("nullable").map(JsonValue::requireBoolean).ifPresent(builder::nullable);
+        }
         if (config.useDefaults) {
             ls.schemaJson().maybe("default").map(JsonValue::deepToOrgJson).ifPresent(builder::defaultValue);
         }

--- a/core/src/main/java/org/everit/json/schema/loader/SchemaLoader.java
+++ b/core/src/main/java/org/everit/json/schema/loader/SchemaLoader.java
@@ -369,17 +369,24 @@ public class SchemaLoader {
                         }
                     });
         }
+        loadCommonSchemaProperties(builder);
+        return builder;
+    }
+
+    private void loadCommonSchemaProperties(Schema.Builder builder) {
         ls.schemaJson().maybe(config.specVersion.idKeyword()).map(JsonValue::requireString).ifPresent(builder::id);
         ls.schemaJson().maybe("title").map(JsonValue::requireString).ifPresent(builder::title);
         ls.schemaJson().maybe("description").map(JsonValue::requireString).ifPresent(builder::description);
         if (config.nullableSupport) {
-            ls.schemaJson().maybe("nullable").map(JsonValue::requireBoolean).ifPresent(builder::nullable);
+            builder.nullable(ls.schemaJson()
+                    .maybe("nullable")
+                    .map(JsonValue::requireBoolean)
+                    .orElse(Boolean.FALSE));
         }
         if (config.useDefaults) {
             ls.schemaJson().maybe("default").map(JsonValue::deepToOrgJson).ifPresent(builder::defaultValue);
         }
         builder.schemaLocation(new JSONPointer(ls.pointerToCurrentObj).toURIFragment());
-        return builder;
     }
 
     /**

--- a/core/src/test/java/org/everit/json/schema/ArraySchemaTest.java
+++ b/core/src/test/java/org/everit/json/schema/ArraySchemaTest.java
@@ -247,4 +247,10 @@ public class ArraySchemaTest {
                 .expect();
     }
 
+    @Test
+    public void requiresArray_nullable() {
+        ArraySchema subject = ArraySchema.builder().requiresArray(true).nullable(true).build();
+        subject.validate(JSONObject.NULL);
+    }
+
 }

--- a/core/src/test/java/org/everit/json/schema/NullableValidationTest.java
+++ b/core/src/test/java/org/everit/json/schema/NullableValidationTest.java
@@ -1,0 +1,26 @@
+package org.everit.json.schema;
+
+import org.json.JSONObject;
+import org.junit.Test;
+
+public class NullableValidationTest {
+
+    @Test
+    public void testNullableFalse_JSONNull() {
+        TestSupport.failureOf(StringSchema.builder().requiresString(false).nullable(false))
+                .input(JSONObject.NULL)
+                .expectedKeyword("nullable")
+                .expectedMessageFragment("value cannot be null")
+                .expect();
+    }
+
+    @Test
+    public void testNullableFalse_nullReference() {
+        TestSupport.failureOf(StringSchema.builder().requiresString(false).nullable(false))
+                .input(null)
+                .expectedKeyword("nullable")
+                .expectedMessageFragment("value cannot be null")
+                .expect();
+    }
+
+}

--- a/core/src/test/java/org/everit/json/schema/NumberSchemaTest.java
+++ b/core/src/test/java/org/everit/json/schema/NumberSchemaTest.java
@@ -233,4 +233,25 @@ public class NumberSchemaTest {
                 .expectedMessageFragment("3.0 is not greater than")
                 .expect();
     }
+
+    @Test
+    public void requiresNumber_nullable() {
+        NumberSchema subject = NumberSchema.builder().requiresNumber(true).nullable(true).build();
+        subject.validate(JSONObject.NULL);
+    }
+
+    @Test
+    public void requiresInteger_nullable() {
+        NumberSchema subject = NumberSchema.builder().requiresInteger(true).nullable(true).build();
+        subject.validate(JSONObject.NULL);
+    }
+
+    @Test
+    public void requiresInteger_nonNullable() {
+        Schema.Builder<?> subject = NumberSchema.builder().requiresInteger(true).nullable(false);
+        TestSupport.failureOf(subject)
+                .input(JSONObject.NULL)
+                .expect();
+    }
+
 }

--- a/core/src/test/java/org/everit/json/schema/ObjectSchemaTest.java
+++ b/core/src/test/java/org/everit/json/schema/ObjectSchemaTest.java
@@ -439,4 +439,9 @@ public class ObjectSchemaTest {
 
         subject.validate(new JSONObject("{}"));
     }
+
+    @Test
+    public void requiresObject_stillNullable() {
+        ObjectSchema.builder().requiresObject(true).nullable(true).build().validate(JSONObject.NULL);
+    }
 }

--- a/core/src/test/java/org/everit/json/schema/StringSchemaTest.java
+++ b/core/src/test/java/org/everit/json/schema/StringSchemaTest.java
@@ -28,7 +28,7 @@ import static org.everit.json.schema.TestSupport.buildWithLocation;
 import static org.junit.Assert.assertTrue;
 
 public class StringSchemaTest {
-    
+
     private static Schema loadWithNullableSupport(JSONObject rawSchemaJson) {
         return SchemaLoader.builder().nullableSupport(true).schemaJson(rawSchemaJson).build().load().build();
     }

--- a/core/src/test/java/org/everit/json/schema/StringSchemaTest.java
+++ b/core/src/test/java/org/everit/json/schema/StringSchemaTest.java
@@ -28,6 +28,10 @@ import static org.everit.json.schema.TestSupport.buildWithLocation;
 import static org.junit.Assert.assertTrue;
 
 public class StringSchemaTest {
+    
+    private static Schema loadWithNullableSupport(JSONObject rawSchemaJson) {
+        return SchemaLoader.builder().nullableSupport(true).schemaJson(rawSchemaJson).build().load().build();
+    }
 
     @Test
     public void formatFailure() {
@@ -120,6 +124,22 @@ public class StringSchemaTest {
     public void toStringTest() {
         JSONObject rawSchemaJson = ResourceLoader.DEFAULT.readObj("tostring/stringschema.json");
         String actual = SchemaLoader.load(rawSchemaJson).toString();
+        assertTrue(ObjectComparator.deepEquals(rawSchemaJson, new JSONObject(actual)));
+    }
+
+    @Test
+    public void toStringWithNullableTrueTest() {
+        JSONObject rawSchemaJson = ResourceLoader.DEFAULT.readObj("tostring/stringschema.json");
+        rawSchemaJson.put("nullable", true);
+        String actual = loadWithNullableSupport(rawSchemaJson).toString();
+        assertTrue(ObjectComparator.deepEquals(rawSchemaJson, new JSONObject(actual)));
+    }
+
+    @Test
+    public void toStringWithNullableFalseTest() {
+        JSONObject rawSchemaJson = ResourceLoader.DEFAULT.readObj("tostring/stringschema.json");
+        rawSchemaJson.put("nullable", false);
+        String actual = loadWithNullableSupport(rawSchemaJson).toString();
         assertTrue(ObjectComparator.deepEquals(rawSchemaJson, new JSONObject(actual)));
     }
 

--- a/core/src/test/java/org/everit/json/schema/StringSchemaTest.java
+++ b/core/src/test/java/org/everit/json/schema/StringSchemaTest.java
@@ -158,4 +158,10 @@ public class StringSchemaTest {
         String actual = SchemaLoader.load(rawSchemaJson).toString();
         assertTrue(ObjectComparator.deepEquals(rawSchemaJson, new JSONObject(actual)));
     }
+
+    @Test
+    public void requiresString_nullable() {
+        Schema subject = StringSchema.builder().requiresString(true).nullable(true).build();
+        subject.validate(JSONObject.NULL);
+    }
 }

--- a/core/src/test/java/org/everit/json/schema/ValidatingVisitorTest.java
+++ b/core/src/test/java/org/everit/json/schema/ValidatingVisitorTest.java
@@ -1,0 +1,71 @@
+package org.everit.json.schema;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
+
+import org.json.JSONObject;
+import org.junit.Before;
+import org.junit.Test;
+
+public class ValidatingVisitorTest {
+
+    private ValidationFailureReporter reporter;
+
+
+    @Before
+    public void before() {
+        reporter = mock(ValidationFailureReporter.class);
+    }
+
+    @Test
+    public void passesTypeCheck_otherType_noRequires() {
+        ValidatingVisitor subject = new ValidatingVisitor("string", reporter);
+        assertFalse(subject.passesTypeCheck(JSONObject.class, false, null));
+        verifyZeroInteractions(reporter);
+    }
+
+    @Test
+    public void passesTypeCheck_otherType_requires() {
+        ValidatingVisitor subject = new ValidatingVisitor("string", reporter);
+        assertFalse(subject.passesTypeCheck(JSONObject.class, true, null));
+        verify(reporter).failure(JSONObject.class, "string");
+    }
+
+    @Test
+    public void passesTypeCheck_otherType_nullPermitted_nullObject() {
+        ValidatingVisitor subject = new ValidatingVisitor(JSONObject.NULL, reporter);
+        assertFalse(subject.passesTypeCheck(JSONObject.class, true, Boolean.TRUE));
+        verifyZeroInteractions(reporter);
+    }
+
+    @Test
+    public void passesTypeCheck_otherType_nullPermitted_nullReference() {
+        ValidatingVisitor subject = new ValidatingVisitor(null, reporter);
+        assertFalse(subject.passesTypeCheck(JSONObject.class, true, Boolean.TRUE));
+        verifyZeroInteractions(reporter);
+    }
+
+    @Test
+    public void passesTypeCheck_nullPermitted_nonNullValue() {
+        ValidatingVisitor subject = new ValidatingVisitor("string", reporter);
+        assertFalse(subject.passesTypeCheck(JSONObject.class, true, Boolean.TRUE));
+        verify(reporter).failure(JSONObject.class, "string");
+    }
+
+    @Test
+    public void passesTypeCheck_requiresType_nullableIsNull() {
+        ValidatingVisitor subject = new ValidatingVisitor(null, reporter);
+        assertFalse(subject.passesTypeCheck(JSONObject.class, true, null));
+        verify(reporter).failure(JSONObject.class, null);
+    }
+
+    @Test
+    public void passesTypeCheck_sameType() {
+        ValidatingVisitor subject = new ValidatingVisitor("string", reporter);
+        assertTrue(subject.passesTypeCheck(String.class, true, Boolean.TRUE));
+        verifyZeroInteractions(reporter);
+    }
+}

--- a/core/src/test/java/org/everit/json/schema/loader/SchemaLoaderTest.java
+++ b/core/src/test/java/org/everit/json/schema/loader/SchemaLoaderTest.java
@@ -9,6 +9,7 @@ import static org.everit.json.schema.loader.SpecificationVersion.DRAFT_6;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -353,7 +354,7 @@ public class SchemaLoaderTest {
     public void tupleSchema() {
         ArraySchema actual = (ArraySchema) SchemaLoader.load(get("tupleSchema"));
         assertFalse(actual.permitsAdditionalItems());
-        Assert.assertNull(actual.getAllItemSchema());
+        assertNull(actual.getAllItemSchema());
         assertEquals(2, actual.getItemSchemas().size());
         assertEquals(BooleanSchema.INSTANCE, actual.getItemSchemas().get(0));
         assertEquals(NullSchema.INSTANCE, actual.getItemSchemas().get(1));
@@ -578,5 +579,29 @@ public class SchemaLoaderTest {
         schema.validate(obj);
 
         assertEquals(JSONObject.NULL, obj.get("nullDefault"));
+    }
+
+    @Test
+    public void nullableBooleansAre_Loaded_withNullableSupport() {
+        SchemaLoader loader = SchemaLoader.builder()
+                .nullableSupport(true)
+                .schemaJson(get("nullableSupport"))
+                .build();
+        ObjectSchema actual = (ObjectSchema) loader.load().build();
+        Schema nullableSchema = actual.getPropertySchemas().get("isNullable");
+        Schema nonNulableSchema = actual.getPropertySchemas().get("nonNullable");
+
+        assertTrue(nullableSchema.isNullable());
+        assertFalse(nonNulableSchema.isNullable());
+    }
+
+    @Test
+    public void nullableBooleansAre_NotLoaded_withoutNullableSupport() {
+        ObjectSchema actual = (ObjectSchema) SchemaLoader.load(get("nullableSupport"));
+        Schema nullableSchema = actual.getPropertySchemas().get("isNullable");
+        Schema nonNulableSchema = actual.getPropertySchemas().get("nonNullable");
+
+        assertNull(nullableSchema.isNullable());
+        assertNull(nonNulableSchema.isNullable());
     }
 }

--- a/core/src/test/java/org/everit/json/schema/loader/SchemaLoaderTest.java
+++ b/core/src/test/java/org/everit/json/schema/loader/SchemaLoaderTest.java
@@ -589,19 +589,23 @@ public class SchemaLoaderTest {
                 .build();
         ObjectSchema actual = (ObjectSchema) loader.load().build();
         Schema nullableSchema = actual.getPropertySchemas().get("isNullable");
-        Schema nonNulableSchema = actual.getPropertySchemas().get("nonNullable");
+        Schema nonNullableSchema = actual.getPropertySchemas().get("nonNullable");
+        Schema implicitNonNullable = actual.getPropertySchemas().get("implicitNonNullable");
 
         assertTrue(nullableSchema.isNullable());
-        assertFalse(nonNulableSchema.isNullable());
+        assertFalse(nonNullableSchema.isNullable());
+        assertFalse(implicitNonNullable.isNullable());
     }
 
     @Test
     public void nullableBooleansAre_NotLoaded_withoutNullableSupport() {
         ObjectSchema actual = (ObjectSchema) SchemaLoader.load(get("nullableSupport"));
         Schema nullableSchema = actual.getPropertySchemas().get("isNullable");
-        Schema nonNulableSchema = actual.getPropertySchemas().get("nonNullable");
+        Schema nonNullableSchema = actual.getPropertySchemas().get("nonNullable");
+        Schema implicitNonNullable = actual.getPropertySchemas().get("implicitNonNullable");
 
         assertNull(nullableSchema.isNullable());
-        assertNull(nonNulableSchema.isNullable());
+        assertNull(nonNullableSchema.isNullable());
+        assertNull(implicitNonNullable.isNullable());
     }
 }

--- a/core/src/test/resources/org/everit/jsonvalidator/testschemas.json
+++ b/core/src/test/resources/org/everit/jsonvalidator/testschemas.json
@@ -587,5 +587,17 @@
         "default": null
       }
     }
+  },
+  "nullableSupport": {
+    "properties": {
+      "nonNullable": {
+        "type": "number",
+        "nullable": false
+      },
+      "isNullable": {
+        "type": "string",
+        "nullable": true
+      }
+    }
   }
 }

--- a/core/src/test/resources/org/everit/jsonvalidator/testschemas.json
+++ b/core/src/test/resources/org/everit/jsonvalidator/testschemas.json
@@ -597,6 +597,9 @@
       "isNullable": {
         "type": "string",
         "nullable": true
+      },
+      "implicitNonNullable": {
+        "type": "string"
       }
     }
   }


### PR DESCRIPTION
This PR is an implementation of the [nullable keyword of OpenAPI](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#schemaNullable) which is not the part of any json schema spec versions.

The feature does not work out of the box and should be explicitly turned on by calling `SchemaLoaderBuilder#nullableSupport(true)` before loading the schema.