### PR TITLE
fix NPE when calling getPattern()

### DIFF
--- a/core/src/main/java/org/everit/json/schema/StringSchema.java
+++ b/core/src/main/java/org/everit/json/schema/StringSchema.java
@@ -120,7 +120,11 @@ public class StringSchema extends Schema {
     }
 
     public java.util.regex.Pattern getPattern() {
-        return java.util.regex.Pattern.compile(pattern.toString());
+        if (pattern == null) {
+            return null;
+        } else {
+            return java.util.regex.Pattern.compile(pattern.toString());
+        }
     }
 
     @Override void accept(Visitor visitor) {

--- a/core/src/test/java/org/everit/json/schema/StringSchemaTest.java
+++ b/core/src/test/java/org/everit/json/schema/StringSchemaTest.java
@@ -26,6 +26,8 @@ import org.junit.Test;
 import java.util.Optional;
 
 import static org.everit.json.schema.TestSupport.buildWithLocation;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 public class StringSchemaTest {
@@ -166,4 +168,19 @@ public class StringSchemaTest {
         Schema subject = StringSchema.builder().requiresString(true).nullable(true).build();
         subject.validate(JSONObject.NULL);
     }
+
+    @Test
+    public void getConvertedPattern() {
+        StringSchema subject = StringSchema.builder().pattern("my\\\\/[p]a[tt]ern").build();
+        assertEquals("my\\\\/[p]a[tt]ern", subject.getRE2JPattern().toString());
+        assertEquals("my\\\\/[p]a[tt]ern", subject.getPattern().toString());
+    }
+
+    @Test
+    public void getConvertedNullPattern() {
+        StringSchema subject = StringSchema.builder().build();
+        assertNull(subject.getRE2JPattern());
+        assertNull(subject.getPattern());
+    }
+
 }


### PR DESCRIPTION
- fix NPE for `null` pattern when calling `getPattern()`
- increasing code coverage a tiny bit

related to issue #147