### PR TITLE
Fix issue where loading the v6 schema overwrites all the custom validators

### DIFF
--- a/core/src/main/java/org/everit/json/schema/loader/LoadingState.java
+++ b/core/src/main/java/org/everit/json/schema/loader/LoadingState.java
@@ -10,6 +10,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -73,7 +74,7 @@ class LoadingState {
     SchemaLoader.SchemaLoaderBuilder initChildLoader() {
         SchemaLoader.SchemaLoaderBuilder rval = SchemaLoader.builder()
                 .httpClient(this.config.httpClient)
-                .formatValidators(this.config.formatValidators)
+                .formatValidators(new HashMap<>(this.config.formatValidators))
                 .resolutionScope(id)
                 .schemaJson(schemaJson)
                 .rootSchemaJson(rootSchemaJson)

--- a/core/src/main/java/org/everit/json/schema/loader/SchemaLoader.java
+++ b/core/src/main/java/org/everit/json/schema/loader/SchemaLoader.java
@@ -106,7 +106,9 @@ public class SchemaLoader {
 
         public SchemaLoaderBuilder draftV6Support() {
             this.specVersion = DRAFT_6;
-            this.formatValidators = new HashMap<>(DRAFT_6.defaultFormatValidators());
+            DRAFT_6.defaultFormatValidators().forEach((formatName, validator) -> {
+                addFormatValidator(formatName, validator);
+            });
             return this;
         }
 

--- a/tests/src/test/resources/org/everit/json/schema/issues/issue152/remotes/customformat-schema.json
+++ b/tests/src/test/resources/org/everit/json/schema/issues/issue152/remotes/customformat-schema.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "http://json-schema.org/draft-06/schema#",
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": "string",
+      "maxLength": 10,
+      "minLength": 3,
+      "format": "evenlength"
+    }
+  },
+  "required": [
+    "id"
+  ]
+}

--- a/tests/src/test/resources/org/everit/json/schema/issues/issue152/schema.json
+++ b/tests/src/test/resources/org/everit/json/schema/issues/issue152/schema.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "http://json-schema.org/draft-06/schema#",
+  "$ref": "http://localhost:1234/customformat-schema.json"
+}

--- a/tests/src/test/resources/org/everit/json/schema/issues/issue152/subject-invalid.json
+++ b/tests/src/test/resources/org/everit/json/schema/issues/issue152/subject-invalid.json
@@ -1,0 +1,4 @@
+{
+	"id": "everitorg"
+}
+


### PR DESCRIPTION
This request is to fix issue 152. The problem is the custom format validators get overwritten when you create the referenced schemas and you are using version 6 of json schema. The fix adds the standard format validators to the reference schema if they don't exist already. It does not to overwrite the validators copied from the parent. 

I hacked in a change to the IssueTest to allow me to add custom format validators. I think that the IssueTest probably needs to allow a SchemaBuilder to be passed in, but I did not want to make a proposal on how to do that. Let me know if there is a better way to add a custom format validator to IssueTest.

Also I made a change to always shut down the jetty service in IssueTest even if there is a failure. 