### PR TITLE
Making RegExp implementation configurable

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -21,7 +21,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.everit.json</groupId>
     <artifactId>org.everit.json.schema</artifactId>
-    <version>1.8.0</version>
+    <version>1.9.0-SNAPSHOT</version>
     <packaging>bundle</packaging>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -69,7 +69,8 @@
                         </Import-Package>
                         <Export-Package>
                             ${project.artifactId};version=${project.version},
-                            ${project.artifactId}.loader;version=${project.version}
+                            ${project.artifactId}.loader;version=${project.version},
+                            ${project.artifactId}.regexp;version=${project.version}
                         </Export-Package>
                     </instructions>
                 </configuration>

--- a/core/src/main/java/org/everit/json/schema/StringSchema.java
+++ b/core/src/main/java/org/everit/json/schema/StringSchema.java
@@ -6,8 +6,8 @@ import static org.everit.json.schema.FormatValidator.NONE;
 import java.util.Objects;
 
 import org.everit.json.schema.internal.JSONPrinter;
-
-import com.google.re2j.Pattern;
+import org.everit.json.schema.regexp.JavaUtilRegexpFactory;
+import org.everit.json.schema.regexp.Regexp;
 
 /**
  * {@code String} schema validator.
@@ -23,7 +23,7 @@ public class StringSchema extends Schema {
 
         private Integer maxLength;
 
-        private String pattern;
+        private Regexp pattern;
 
         private boolean requiresString = true;
 
@@ -59,6 +59,10 @@ public class StringSchema extends Schema {
         }
 
         public Builder pattern(final String pattern) {
+            return pattern(new JavaUtilRegexpFactory().createHandler(pattern));
+        }
+
+        public Builder pattern(Regexp pattern) {
             this.pattern = pattern;
             return this;
         }
@@ -78,7 +82,7 @@ public class StringSchema extends Schema {
 
     private final Integer maxLength;
 
-    private final Pattern pattern;
+    private final Regexp pattern;
 
     private final boolean requiresString;
 
@@ -99,11 +103,8 @@ public class StringSchema extends Schema {
         this.minLength = builder.minLength;
         this.maxLength = builder.maxLength;
         this.requiresString = builder.requiresString;
-        if (builder.pattern != null) {
-            this.pattern = Pattern.compile(builder.pattern);
-        } else {
-            this.pattern = null;
-        }
+        this.pattern = builder.pattern;
+        System.out.println(builder.pattern);
         this.formatValidator = builder.formatValidator;
     }
 
@@ -115,7 +116,7 @@ public class StringSchema extends Schema {
         return minLength;
     }
 
-    Pattern getRE2JPattern() {
+    Regexp getRegexpPattern() {
         return pattern;
     }
 
@@ -123,7 +124,7 @@ public class StringSchema extends Schema {
         if (pattern == null) {
             return null;
         } else {
-            return java.util.regex.Pattern.compile(pattern.toString());
+            return java.util.regex.Pattern.compile(pattern.asString());
         }
     }
 
@@ -141,19 +142,11 @@ public class StringSchema extends Schema {
                     requiresString == that.requiresString &&
                     Objects.equals(minLength, that.minLength) &&
                     Objects.equals(maxLength, that.maxLength) &&
-                    Objects.equals(patternIfNotNull(pattern), patternIfNotNull(that.pattern)) &&
+                    Objects.equals(pattern, that.pattern) &&
                     Objects.equals(formatValidator, that.formatValidator) &&
                     super.equals(that);
         } else {
             return false;
-        }
-    }
-
-    private String patternIfNotNull(Pattern pattern) {
-        if (pattern == null) {
-            return null;
-        } else {
-            return pattern.pattern();
         }
     }
 

--- a/core/src/main/java/org/everit/json/schema/StringSchema.java
+++ b/core/src/main/java/org/everit/json/schema/StringSchema.java
@@ -123,7 +123,7 @@ public class StringSchema extends Schema {
         if (pattern == null) {
             return null;
         } else {
-            return java.util.regex.Pattern.compile(pattern.asString());
+            return java.util.regex.Pattern.compile(pattern.toString());
         }
     }
 

--- a/core/src/main/java/org/everit/json/schema/StringSchema.java
+++ b/core/src/main/java/org/everit/json/schema/StringSchema.java
@@ -104,7 +104,6 @@ public class StringSchema extends Schema {
         this.maxLength = builder.maxLength;
         this.requiresString = builder.requiresString;
         this.pattern = builder.pattern;
-        System.out.println(builder.pattern);
         this.formatValidator = builder.formatValidator;
     }
 

--- a/core/src/main/java/org/everit/json/schema/StringSchemaValidatingVisitor.java
+++ b/core/src/main/java/org/everit/json/schema/StringSchemaValidatingVisitor.java
@@ -46,7 +46,7 @@ public class StringSchemaValidatingVisitor extends Visitor {
 
     @Override void visitPattern(Regexp pattern) {
         if (pattern != null && pattern.patternMatchingFailure(stringSubject).isPresent()) {
-            String message = format("string [%s] does not match pattern %s", subject, pattern.asString());
+            String message = format("string [%s] does not match pattern %s", subject, pattern.toString());
             owner.failure(message, "pattern");
         }
     }

--- a/core/src/main/java/org/everit/json/schema/StringSchemaValidatingVisitor.java
+++ b/core/src/main/java/org/everit/json/schema/StringSchemaValidatingVisitor.java
@@ -3,8 +3,9 @@ package org.everit.json.schema;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 
-import com.google.re2j.Pattern;
 import java.util.Optional;
+
+import org.everit.json.schema.regexp.Regexp;
 
 public class StringSchemaValidatingVisitor extends Visitor {
 
@@ -43,10 +44,11 @@ public class StringSchemaValidatingVisitor extends Visitor {
         }
     }
 
-    @Override void visitPattern(Pattern pattern) {
-        if (pattern != null && !pattern.matcher(stringSubject).find()) {
-            String message = format("string [%s] does not match pattern %s",
-                    subject, pattern.pattern());
+    @Override void visitPattern(Regexp pattern) {
+        System.out.println("chk" + pattern);
+        if (pattern != null && pattern.patternMatchingFailure(stringSubject).isPresent()) {
+            System.out.println("->fail");
+            String message = format("string [%s] does not match pattern %s", subject, pattern.asString());
             owner.failure(message, "pattern");
         }
     }

--- a/core/src/main/java/org/everit/json/schema/StringSchemaValidatingVisitor.java
+++ b/core/src/main/java/org/everit/json/schema/StringSchemaValidatingVisitor.java
@@ -45,9 +45,7 @@ public class StringSchemaValidatingVisitor extends Visitor {
     }
 
     @Override void visitPattern(Regexp pattern) {
-        System.out.println("chk" + pattern);
         if (pattern != null && pattern.patternMatchingFailure(stringSubject).isPresent()) {
-            System.out.println("->fail");
             String message = format("string [%s] does not match pattern %s", subject, pattern.asString());
             owner.failure(message, "pattern");
         }

--- a/core/src/main/java/org/everit/json/schema/Visitor.java
+++ b/core/src/main/java/org/everit/json/schema/Visitor.java
@@ -4,6 +4,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import org.everit.json.schema.regexp.Regexp;
+
 import com.google.re2j.Pattern;
 
 abstract class Visitor {
@@ -166,14 +168,14 @@ abstract class Visitor {
     void visitStringSchema(StringSchema stringSchema) {
         visitMinLength(stringSchema.getMinLength());
         visitMaxLength(stringSchema.getMaxLength());
-        visitPattern(stringSchema.getRE2JPattern());
+        visitPattern(stringSchema.getRegexpPattern());
         visitFormat(stringSchema.getFormatValidator());
     }
 
     void visitFormat(FormatValidator formatValidator) {
     }
 
-    void visitPattern(Pattern pattern) {
+    void visitPattern(Regexp pattern) {
     }
 
     void visitMaxLength(Integer maxLength) {
@@ -185,7 +187,7 @@ abstract class Visitor {
     void visitCombinedSchema(CombinedSchema combinedSchema) {
     }
 
-    void visitConditionalSchema(ConditionalSchema conditionalSchema){
+    void visitConditionalSchema(ConditionalSchema conditionalSchema) {
         conditionalSchema.getIfSchema().ifPresent(this::visitIfSchema);
         conditionalSchema.getThenSchema().ifPresent(this::visitThenSchema);
         conditionalSchema.getElseSchema().ifPresent(this::visitElseSchema);

--- a/core/src/main/java/org/everit/json/schema/loader/LoaderConfig.java
+++ b/core/src/main/java/org/everit/json/schema/loader/LoaderConfig.java
@@ -7,6 +7,8 @@ import java.util.Map;
 
 import org.everit.json.schema.FormatValidator;
 import org.everit.json.schema.loader.internal.DefaultSchemaClient;
+import org.everit.json.schema.regexp.JavaUtilRegexpFactory;
+import org.everit.json.schema.regexp.RegexpFactory;
 
 /**
  * @author erosb
@@ -27,18 +29,22 @@ class LoaderConfig {
 
     final boolean nullableSupport;
 
+    final RegexpFactory regexpFactory;
+
     LoaderConfig(SchemaClient httpClient, Map<String, FormatValidator> formatValidators,
             SpecificationVersion specVersion, boolean useDefaults) {
-        this(httpClient, formatValidators, specVersion, useDefaults, false);
+        this(httpClient, formatValidators, specVersion, useDefaults, false, new JavaUtilRegexpFactory());
     }
 
     LoaderConfig(SchemaClient httpClient, Map<String, FormatValidator> formatValidators,
-            SpecificationVersion specVersion, boolean useDefaults, boolean nullableSupport) {
+            SpecificationVersion specVersion, boolean useDefaults, boolean nullableSupport,
+            RegexpFactory regexpFactory) {
         this.httpClient = requireNonNull(httpClient, "httpClient cannot be null");
         this.formatValidators = requireNonNull(formatValidators, "formatValidators cannot be null");
         this.specVersion = requireNonNull(specVersion, "specVersion cannot be null");
         this.useDefaults = useDefaults;
         this.nullableSupport = nullableSupport;
+        this.regexpFactory = requireNonNull(regexpFactory, "regexpFactory cannot be null");
     }
 
 }

--- a/core/src/main/java/org/everit/json/schema/loader/SchemaLoader.java
+++ b/core/src/main/java/org/everit/json/schema/loader/SchemaLoader.java
@@ -38,6 +38,8 @@ import org.everit.json.schema.SchemaException;
 import org.everit.json.schema.TrueSchema;
 import org.everit.json.schema.loader.internal.DefaultSchemaClient;
 import org.everit.json.schema.loader.internal.WrappingFormatValidator;
+import org.everit.json.schema.regexp.JavaUtilRegexpFactory;
+import org.everit.json.schema.regexp.RegexpFactory;
 import org.json.JSONObject;
 import org.json.JSONPointer;
 
@@ -74,6 +76,8 @@ public class SchemaLoader {
         boolean useDefaults = false;
 
         private boolean nullableSupport = false;
+
+        RegexpFactory regexpFactory = new JavaUtilRegexpFactory();
 
         public SchemaLoaderBuilder() {
             setSpecVersion(DRAFT_4);
@@ -219,6 +223,11 @@ public class SchemaLoader {
             this.nullableSupport = nullableSupport;
             return this;
         }
+
+        public SchemaLoaderBuilder regexpFactory(RegexpFactory regexpFactory) {
+            this.regexpFactory = regexpFactory;
+            return this;
+        }
     }
 
     private static final List<String> CONDITIONAL_SCHEMA_KEYWORDS = asList("if", "then", "else");
@@ -283,7 +292,8 @@ public class SchemaLoader {
                 builder.formatValidators,
                 builder.specVersion,
                 builder.useDefaults,
-                builder.nullableSupport);
+                builder.nullableSupport,
+                builder.regexpFactory);
         this.ls = new LoadingState(config,
                 builder.pointerSchemas,
                 builder.rootSchemaJson == null ? builder.schemaJson : builder.rootSchemaJson,

--- a/core/src/main/java/org/everit/json/schema/loader/StringSchemaLoader.java
+++ b/core/src/main/java/org/everit/json/schema/loader/StringSchemaLoader.java
@@ -39,7 +39,9 @@ public class StringSchemaLoader {
         StringSchema.Builder builder = StringSchema.builder();
         ls.schemaJson().maybe("minLength").map(JsonValue::requireInteger).ifPresent(builder::minLength);
         ls.schemaJson().maybe("maxLength").map(JsonValue::requireInteger).ifPresent(builder::maxLength);
-        ls.schemaJson().maybe("pattern").map(JsonValue::requireString).ifPresent(builder::pattern);
+        ls.schemaJson().maybe("pattern").map(JsonValue::requireString)
+                .map(ls.config.regexpFactory::createHandler)
+                .ifPresent(builder::pattern);
         ls.schemaJson().maybe("format").map(JsonValue::requireString)
                 .ifPresent(format -> addFormatValidator(builder, format));
         return builder;

--- a/core/src/main/java/org/everit/json/schema/regexp/JavaUtilRegexpFactory.java
+++ b/core/src/main/java/org/everit/json/schema/regexp/JavaUtilRegexpFactory.java
@@ -1,0 +1,29 @@
+package org.everit.json.schema.regexp;
+
+import java.util.Optional;
+import java.util.regex.Pattern;
+
+class JavaUtilRegexp extends AbstractRegexp {
+
+    private final Pattern pattern;
+
+    JavaUtilRegexp(String pattern) {
+        super(pattern);
+        this.pattern = Pattern.compile(pattern);
+    }
+
+    @Override public Optional<RegexpMatchingFailure> patternMatchingFailure(String input) {
+        if (pattern.matcher(input).matches()) {
+            return Optional.empty();
+        } else {
+            return Optional.of(new RegexpMatchingFailure());
+        }
+    }
+
+}
+
+public class JavaUtilRegexpFactory implements RegexpFactory {
+    @Override public Regexp createHandler(String regexp) {
+        return new JavaUtilRegexp(regexp);
+    }
+}

--- a/core/src/main/java/org/everit/json/schema/regexp/JavaUtilRegexpFactory.java
+++ b/core/src/main/java/org/everit/json/schema/regexp/JavaUtilRegexpFactory.java
@@ -13,7 +13,7 @@ class JavaUtilRegexp extends AbstractRegexp {
     }
 
     @Override public Optional<RegexpMatchingFailure> patternMatchingFailure(String input) {
-        if (pattern.matcher(input).matches()) {
+        if (pattern.matcher(input).find()) {
             return Optional.empty();
         } else {
             return Optional.of(new RegexpMatchingFailure());

--- a/core/src/main/java/org/everit/json/schema/regexp/RE2JRegexpFactory.java
+++ b/core/src/main/java/org/everit/json/schema/regexp/RE2JRegexpFactory.java
@@ -1,0 +1,30 @@
+package org.everit.json.schema.regexp;
+
+import java.util.Optional;
+
+import com.google.re2j.Pattern;
+
+class RE2JRegexp extends AbstractRegexp {
+
+    private Pattern pattern;
+
+    RE2JRegexp(String pattern) {
+        super(pattern);
+        this.pattern = Pattern.compile(pattern);
+    }
+
+    @Override public Optional<RegexpMatchingFailure> patternMatchingFailure(String input) {
+        if (pattern.matcher(input).matches()) {
+            return Optional.empty();
+        } else {
+            return Optional.of(new RegexpMatchingFailure());
+        }
+    }
+
+}
+
+public class RE2JRegexpFactory implements RegexpFactory {
+    @Override public Regexp createHandler(String input) {
+        return new RE2JRegexp(input);
+    }
+}

--- a/core/src/main/java/org/everit/json/schema/regexp/RE2JRegexpFactory.java
+++ b/core/src/main/java/org/everit/json/schema/regexp/RE2JRegexpFactory.java
@@ -14,7 +14,7 @@ class RE2JRegexp extends AbstractRegexp {
     }
 
     @Override public Optional<RegexpMatchingFailure> patternMatchingFailure(String input) {
-        if (pattern.matcher(input).matches()) {
+        if (pattern.matcher(input).find()) {
             return Optional.empty();
         } else {
             return Optional.of(new RegexpMatchingFailure());

--- a/core/src/main/java/org/everit/json/schema/regexp/Regexp.java
+++ b/core/src/main/java/org/everit/json/schema/regexp/Regexp.java
@@ -8,7 +8,6 @@ public interface Regexp {
 
     Optional<RegexpMatchingFailure> patternMatchingFailure(String input);
 
-    String asString();
 }
 
 abstract class AbstractRegexp implements Regexp {
@@ -19,11 +18,7 @@ abstract class AbstractRegexp implements Regexp {
         this.asString = requireNonNull(asString, "asString cannot be null");
     }
 
-    @Override public String asString() {
-        return asString;
-    }
-
     @Override public String toString() {
-        return asString();
+        return asString;
     }
 }

--- a/core/src/main/java/org/everit/json/schema/regexp/Regexp.java
+++ b/core/src/main/java/org/everit/json/schema/regexp/Regexp.java
@@ -1,0 +1,29 @@
+package org.everit.json.schema.regexp;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.Optional;
+
+public interface Regexp {
+
+    Optional<RegexpMatchingFailure> patternMatchingFailure(String input);
+
+    String asString();
+}
+
+abstract class AbstractRegexp implements Regexp {
+
+    private final String asString;
+
+    AbstractRegexp(String asString) {
+        this.asString = requireNonNull(asString, "asString cannot be null");
+    }
+
+    @Override public String asString() {
+        return asString;
+    }
+
+    @Override public String toString() {
+        return asString();
+    }
+}

--- a/core/src/main/java/org/everit/json/schema/regexp/RegexpFactory.java
+++ b/core/src/main/java/org/everit/json/schema/regexp/RegexpFactory.java
@@ -1,0 +1,7 @@
+package org.everit.json.schema.regexp;
+
+public interface RegexpFactory {
+
+    Regexp createHandler(String input);
+
+}

--- a/core/src/main/java/org/everit/json/schema/regexp/RegexpMatchingFailure.java
+++ b/core/src/main/java/org/everit/json/schema/regexp/RegexpMatchingFailure.java
@@ -1,0 +1,15 @@
+package org.everit.json.schema.regexp;
+
+public class RegexpMatchingFailure {
+
+    RegexpMatchingFailure() {
+    }
+
+    @Override public int hashCode() {
+        return super.hashCode();
+    }
+
+    @Override public boolean equals(Object obj) {
+        return obj instanceof RegexpMatchingFailure;
+    }
+}

--- a/core/src/main/java/org/everit/json/schema/regexp/RegexpMatchingFailure.java
+++ b/core/src/main/java/org/everit/json/schema/regexp/RegexpMatchingFailure.java
@@ -5,10 +5,6 @@ public class RegexpMatchingFailure {
     RegexpMatchingFailure() {
     }
 
-    @Override public int hashCode() {
-        return super.hashCode();
-    }
-
     @Override public boolean equals(Object obj) {
         return obj instanceof RegexpMatchingFailure;
     }

--- a/core/src/test/java/org/everit/json/schema/StringSchemaTest.java
+++ b/core/src/test/java/org/everit/json/schema/StringSchemaTest.java
@@ -169,14 +169,14 @@ public class StringSchemaTest {
     @Test
     public void getConvertedPattern() {
         StringSchema subject = StringSchema.builder().pattern("my\\\\/[p]a[tt]ern").build();
-        assertEquals("my\\\\/[p]a[tt]ern", subject.getRE2JPattern().toString());
+        assertEquals("my\\\\/[p]a[tt]ern", subject.getRegexpPattern().asString());
         assertEquals("my\\\\/[p]a[tt]ern", subject.getPattern().toString());
     }
 
     @Test
     public void getConvertedNullPattern() {
         StringSchema subject = StringSchema.builder().build();
-        assertNull(subject.getRE2JPattern());
+        assertNull(subject.getRegexpPattern());
         assertNull(subject.getPattern());
     }
 

--- a/core/src/test/java/org/everit/json/schema/StringSchemaTest.java
+++ b/core/src/test/java/org/everit/json/schema/StringSchemaTest.java
@@ -9,6 +9,7 @@ import static org.junit.Assert.assertTrue;
 import java.util.Optional;
 
 import org.everit.json.schema.loader.SchemaLoader;
+import org.everit.json.schema.regexp.RE2JRegexpFactory;
 import org.json.JSONObject;
 import org.junit.Assert;
 import org.junit.Test;
@@ -178,6 +179,18 @@ public class StringSchemaTest {
         StringSchema subject = StringSchema.builder().build();
         assertNull(subject.getRegexpPattern());
         assertNull(subject.getPattern());
+    }
+
+    @Test
+    public void regexpFactoryIsUsedByLoader() {
+        SchemaLoader loader = SchemaLoader.builder()
+                .regexpFactory(new RE2JRegexpFactory())
+                .schemaJson(ResourceLoader.DEFAULT.readObj("tostring/stringschema.json"))
+                .build();
+
+        StringSchema result = (StringSchema) loader.load().build();
+
+        assertEquals(result.getRegexpPattern().getClass().getSimpleName(), "RE2JRegexp");
     }
 
 }

--- a/core/src/test/java/org/everit/json/schema/StringSchemaTest.java
+++ b/core/src/test/java/org/everit/json/schema/StringSchemaTest.java
@@ -170,7 +170,7 @@ public class StringSchemaTest {
     @Test
     public void getConvertedPattern() {
         StringSchema subject = StringSchema.builder().pattern("my\\\\/[p]a[tt]ern").build();
-        assertEquals("my\\\\/[p]a[tt]ern", subject.getRegexpPattern().asString());
+        assertEquals("my\\\\/[p]a[tt]ern", subject.getRegexpPattern().toString());
         assertEquals("my\\\\/[p]a[tt]ern", subject.getPattern().toString());
     }
 

--- a/core/src/test/java/org/everit/json/schema/regexp/JavaUtilRegexpTest.java
+++ b/core/src/test/java/org/everit/json/schema/regexp/JavaUtilRegexpTest.java
@@ -1,0 +1,33 @@
+package org.everit.json.schema.regexp;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+
+import java.util.Optional;
+
+import org.junit.Test;
+
+public class JavaUtilRegexpTest {
+
+    static final String PATTERN = "^aa.*b$";
+
+    private Regexp createHandler() {
+        return new JavaUtilRegexpFactory().createHandler(PATTERN);
+    }
+
+    @Test
+    public void success() {
+        assertSame(Optional.empty(), createHandler().patternMatchingFailure("aaaaaaaaab"));
+    }
+
+    @Test
+    public void failure() {
+        assertEquals(Optional.of(new RegexpMatchingFailure()), createHandler().patternMatchingFailure("xxx"));
+    }
+
+    @Test
+    public void asString() {
+        assertEquals(PATTERN, createHandler().asString());
+    }
+
+}

--- a/core/src/test/java/org/everit/json/schema/regexp/JavaUtilRegexpTest.java
+++ b/core/src/test/java/org/everit/json/schema/regexp/JavaUtilRegexpTest.java
@@ -27,7 +27,7 @@ public class JavaUtilRegexpTest {
 
     @Test
     public void asString() {
-        assertEquals(PATTERN, createHandler().asString());
+        assertEquals(PATTERN, createHandler().toString());
     }
 
 }

--- a/core/src/test/java/org/everit/json/schema/regexp/RE2JRegexpTest.java
+++ b/core/src/test/java/org/everit/json/schema/regexp/RE2JRegexpTest.java
@@ -27,7 +27,7 @@ public class RE2JRegexpTest {
 
     @Test
     public void asString() {
-        assertEquals(PATTERN, createHandler().asString());
+        assertEquals(PATTERN, createHandler().toString());
     }
 
 }

--- a/core/src/test/java/org/everit/json/schema/regexp/RE2JRegexpTest.java
+++ b/core/src/test/java/org/everit/json/schema/regexp/RE2JRegexpTest.java
@@ -1,0 +1,33 @@
+package org.everit.json.schema.regexp;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+
+import java.util.Optional;
+
+import org.junit.Test;
+
+public class RE2JRegexpTest {
+
+    static final String PATTERN = "^aa.*b$";
+
+    private Regexp createHandler() {
+        return new RE2JRegexpFactory().createHandler(PATTERN);
+    }
+
+    @Test
+    public void success() {
+        assertSame(Optional.empty(), createHandler().patternMatchingFailure("aaaaaaaaab"));
+    }
+
+    @Test
+    public void failure() {
+        assertEquals(Optional.of(new RegexpMatchingFailure()), createHandler().patternMatchingFailure("xxx"));
+    }
+
+    @Test
+    public void asString() {
+        assertEquals(PATTERN, createHandler().asString());
+    }
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.everit.json</groupId>
     <artifactId>org.everit.json.schema.parent</artifactId>
-    <version>1.8.0</version>
+    <version>1.9.0-SNAPSHOT</version>
 
     <packaging>pom</packaging>
 

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.everit.json</groupId>
         <artifactId>org.everit.json.schema.parent</artifactId>
-        <version>1.8.0</version>
+        <version>1.9.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>org.everit.json.schema.tests</artifactId>

--- a/tests/src/test/resources/org/everit/json/schema/issues/issue147/validator-config.json
+++ b/tests/src/test/resources/org/everit/json/schema/issues/issue147/validator-config.json
@@ -1,0 +1,3 @@
+{
+  "regexpImplementation": "RE2J"
+}


### PR DESCRIPTION
This PR partially reverts #147 , fixes the regression reported in #156 and #157 .

The issue was that the RE2J library doesn't support all possible regular expressions that `java.util.regex` does (at least not the ones ontaining lookaheads).

This is solved by 
 * creating an abstraction layer of regexp solutions, this is the `org.everit.json.schema.regexp` package
 * making the implementation configurable via the  `SchemaLoaderBuilder#regexpFactory(RegexpFactory)` method
 * the default implementation uses the `java.util.regex.Pattern` class, so backward-compatibility is restored
 * people who need re2j can use the `RE2JRegexpFactory` implementation 