### PR TITLE
Fixing regex handling in `"patternProperties"`

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -21,7 +21,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.everit.json</groupId>
     <artifactId>org.everit.json.schema</artifactId>
-    <version>1.9.0</version>
+    <version>1.9.1</version>
     <packaging>bundle</packaging>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/core/src/main/java/org/everit/json/schema/ObjectSchemaValidatingVisitor.java
+++ b/core/src/main/java/org/everit/json/schema/ObjectSchemaValidatingVisitor.java
@@ -3,10 +3,11 @@ package org.everit.json.schema;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 
-import com.google.re2j.Pattern;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
+
+import org.everit.json.schema.regexp.Regexp;
 import org.json.JSONObject;
 
 class ObjectSchemaValidatingVisitor extends Visitor {
@@ -119,21 +120,21 @@ class ObjectSchemaValidatingVisitor extends Visitor {
     }
 
     private boolean matchesAnyPattern(String key) {
-        for (Pattern pattern : schema.getPatternProperties().keySet()) {
-            if (pattern.matcher(key).find()) {
+        for (Regexp pattern : schema.getRegexpPatternProperties().keySet()) {
+            if (!pattern.patternMatchingFailure(key).isPresent()) {
                 return true;
             }
         }
         return false;
     }
 
-    @Override void visitPatternPropertySchema(Pattern propertyNamePattern, Schema schema) {
+    @Override void visitPatternPropertySchema(Regexp propertyNamePattern, Schema schema) {
         String[] propNames = JSONObject.getNames(objSubject);
         if (propNames == null || propNames.length == 0) {
             return;
         }
         for (String propName : propNames) {
-            if (propertyNamePattern.matcher(propName).find()) {
+            if (!propertyNamePattern.patternMatchingFailure(propName).isPresent()) {
                 ValidationException failure = owner.getFailureOfSchema(schema, objSubject.get(propName));
                 if (failure != null) {
                     owner.failure(failure.prepend(propName));

--- a/core/src/main/java/org/everit/json/schema/Visitor.java
+++ b/core/src/main/java/org/everit/json/schema/Visitor.java
@@ -6,8 +6,6 @@ import java.util.Set;
 
 import org.everit.json.schema.regexp.Regexp;
 
-import com.google.re2j.Pattern;
-
 abstract class Visitor {
 
     void visitNumberSchema(NumberSchema numberSchema) {
@@ -121,7 +119,7 @@ abstract class Visitor {
         }
         visitAdditionalProperties(objectSchema.permitsAdditionalProperties());
         visitSchemaOfAdditionalProperties(objectSchema.getSchemaOfAdditionalProperties());
-        for (Map.Entry<Pattern, Schema> entry : objectSchema.getPatternProperties().entrySet()) {
+        for (Map.Entry<Regexp, Schema> entry : objectSchema.getRegexpPatternProperties().entrySet()) {
             visitPatternPropertySchema(entry.getKey(), entry.getValue());
         }
         for (Map.Entry<String, Schema> schemaDep : objectSchema.getSchemaDependencies().entrySet()) {
@@ -141,7 +139,7 @@ abstract class Visitor {
     void visitSchemaDependency(String propKey, Schema schema) {
     }
 
-    void visitPatternPropertySchema(Pattern propertyNamePattern, Schema schema) {
+    void visitPatternPropertySchema(Regexp propertyNamePattern, Schema schema) {
     }
 
     void visitSchemaOfAdditionalProperties(Schema schemaOfAdditionalProperties) {

--- a/core/src/main/java/org/everit/json/schema/loader/ObjectSchemaLoader.java
+++ b/core/src/main/java/org/everit/json/schema/loader/ObjectSchemaLoader.java
@@ -5,6 +5,7 @@ import static org.everit.json.schema.loader.SpecificationVersion.DRAFT_6;
 
 import org.everit.json.schema.ObjectSchema;
 import org.everit.json.schema.Schema;
+import org.everit.json.schema.regexp.Regexp;
 
 /**
  * @author erosb
@@ -40,7 +41,8 @@ class ObjectSchemaLoader {
                 .ifPresent(patternProps -> {
                     patternProps.keySet().forEach(pattern -> {
                         Schema patternSchema = defaultLoader.loadChild(patternProps.require(pattern)).build();
-                        builder.patternProperty(pattern, patternSchema);
+                        Regexp regexp = ls.config.regexpFactory.createHandler(pattern);
+                        builder.patternProperty(regexp, patternSchema);
                     });
                 });
         ls.schemaJson().maybe("dependencies").map(JsonValue::requireObject)

--- a/core/src/test/java/org/everit/json/schema/ObjectSchemaTest.java
+++ b/core/src/test/java/org/everit/json/schema/ObjectSchemaTest.java
@@ -258,7 +258,7 @@ public class ObjectSchemaTest {
     @Test
     public void patternPropertyTranslation() {
         ObjectSchema subject = ObjectSchema.builder()
-                .patternProperty("b_.*", BooleanSchema.INSTANCE)
+                .patternProperty(java.util.regex.Pattern.compile("b_.*"), BooleanSchema.INSTANCE)
                 .build();
         Map<java.util.regex.Pattern, Schema> expected = new HashMap<>();
         expected.put(java.util.regex.Pattern.compile("b_.*"), BooleanSchema.INSTANCE);

--- a/core/src/test/java/org/everit/json/schema/loader/DefinesPropertyTest.java
+++ b/core/src/test/java/org/everit/json/schema/loader/DefinesPropertyTest.java
@@ -1,5 +1,7 @@
 package org.everit.json.schema.loader;
 
+import static org.junit.Assert.assertFalse;
+
 import org.everit.json.schema.BooleanSchema;
 import org.everit.json.schema.CombinedSchema;
 import org.everit.json.schema.ObjectSchema;
@@ -9,8 +11,6 @@ import org.everit.json.schema.ValidationException;
 import org.json.JSONObject;
 import org.junit.Assert;
 import org.junit.Test;
-
-import static org.junit.Assert.assertFalse;
 
 public class DefinesPropertyTest {
 
@@ -53,7 +53,7 @@ public class DefinesPropertyTest {
         Assert.assertTrue(actual.definesProperty("#/aaa"));
         Assert.assertTrue(actual.definesProperty("#/aaaa"));
         Assert.assertTrue(actual.definesProperty("#/aaaaa"));
-
+        
         assertFalse(actual.definesProperty("b"));
     }
 

--- a/core/src/test/resources/org/everit/jsonvalidator/testschemas.json
+++ b/core/src/test/resources/org/everit/jsonvalidator/testschemas.json
@@ -1,7 +1,7 @@
 {
   "patternProperties": {
     "patternProperties": {
-      "a*": {
+      "aa*": {
         "type": "integer"
       },
       "aaa*": {

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.everit.json</groupId>
     <artifactId>org.everit.json.schema.parent</artifactId>
-    <version>1.9.0</version>
+    <version>1.9.1</version>
 
     <packaging>pom</packaging>
 

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.everit.json</groupId>
         <artifactId>org.everit.json.schema.parent</artifactId>
-        <version>1.9.0</version>
+        <version>1.9.1</version>
     </parent>
 
     <artifactId>org.everit.json.schema.tests</artifactId>


### PR DESCRIPTION
Changing `ObjectSchema` to represent `patternProperties` as a `Map<Regexp, Schema>` instead of `Map<Pattern, Schema>`
This is a follow-up change of introducing `Regexp` and `RegexpFactory` interfaces in `1.9.0`.

Keeping but deprecating existing accessor & builder methods of `ObjectSchema` which consume / return a `Pattern`, converting from/to `Regexp`.

In the end, changing `ObjectSchemaLoader` to instantiate a `Regexp` instance using the configured `RegexpFactory` instead of attempting to use RE2J directly.

Also bumping version number to 1.9.1, since it is going to be a quick bugfix release ASAP.