### PR TITLE
Issue #227-Validate child objects

### DIFF
--- a/tests/src/test/resources/org/everit/json/schema/issues/issue227/remotes.subdir/color.json
+++ b/tests/src/test/resources/org/everit/json/schema/issues/issue227/remotes.subdir/color.json
@@ -1,5 +1,5 @@
 {
-  "id":"http://localhost:1234/color.json#",
+  "id":"http://localhost:1234/subdir/color.json#",
   "definitions" : {
     "name" : {
       "type" : "string",

--- a/tests/src/test/resources/org/everit/json/schema/issues/issue227/remotes.subdir/color.json
+++ b/tests/src/test/resources/org/everit/json/schema/issues/issue227/remotes.subdir/color.json
@@ -1,0 +1,9 @@
+{
+  "id":"http://localhost:1234/color.json#",
+  "definitions" : {
+    "name" : {
+      "type" : "string",
+      "enum": ["red", "green"]
+    }
+  }
+}

--- a/tests/src/test/resources/org/everit/json/schema/issues/issue227/schema.json
+++ b/tests/src/test/resources/org/everit/json/schema/issues/issue227/schema.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "id":"http://localhost:1234/rectangle",
+  "type": "object",
+  "properties": {
+    "rectangle": {
+      "$ref": "#/definitions/Rectangle"
+    }
+  },
+  "required": [
+    "rectangle"
+  ],
+  "definitions": {
+    "size": {
+      "type": "number"
+    },
+    "Rectangle": {
+      "type": "object",
+      "id": "http://localhost:1234/neveraccessed",
+      "properties": {
+        "l": {
+          "$ref": "#/definitions/size"
+        },
+        "b": {
+          "$ref": "#/definitions/size"
+        },
+        "bgcolor": {
+          "$ref": "subdir/color.json#/definitions/name"
+        }
+      },
+      "required": [
+        "l",
+        "b",
+        "bgcolor"
+      ]
+    }
+  }
+}

--- a/tests/src/test/resources/org/everit/json/schema/issues/issue227/subject-invalid.json
+++ b/tests/src/test/resources/org/everit/json/schema/issues/issue227/subject-invalid.json
@@ -1,0 +1,7 @@
+{
+  "rectangle": {
+    "l": 5,
+    "b": 6,
+    "bgcolor": "black"
+  }
+}

--- a/tests/src/test/resources/org/everit/json/schema/issues/issue227/subject-valid.json
+++ b/tests/src/test/resources/org/everit/json/schema/issues/issue227/subject-valid.json
@@ -1,0 +1,7 @@
+{
+  "rectangle": {
+    "l": 5,
+    "b": 6,
+    "bgcolor": "green"
+  }
+}


### PR DESCRIPTION
Hi there, attached is a test case that fails with 
`java.io.UncheckedIOException: java.net.MalformedURLException: no protocol: subdir/color.json
	at org.everit.json.schema.loader.internal.DefaultSchemaClient.get(DefaultSchemaClient.java:20)
	at org.everit.json.schema.loader.JsonPointerEvaluator.executeWith(JsonPointerEvaluator.java:76)`

The need is to have multiple schemas defining its own objects; one object defined in one separate schema file. I want to be able to refer to the child objects and validate them, allowing users to pass entire payload (parent + child objects data) in a nested form.

I expect all the schemas to be available locally and very few in remote. For all local schemas, I'd like to have strict validation and for those in remote, on a case-to-case basis. 