### PR TITLE
Refactor JSON API into own Module

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -143,11 +143,13 @@
         </plugins>
     </build>
     <dependencies>
+        <!-- TODO: Move into own artifact-->
         <dependency>
             <groupId>org.json</groupId>
             <artifactId>json</artifactId>
             <version>20180130</version>
         </dependency>
+        <!-- -->
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>

--- a/core/src/main/java/org/everit/json/schema/ArraySchemaValidatingVisitor.java
+++ b/core/src/main/java/org/everit/json/schema/ArraySchemaValidatingVisitor.java
@@ -18,6 +18,7 @@ class ArraySchemaValidatingVisitor extends Visitor {
 
     private final ValidatingVisitor owner;
 
+    // TODO: New API (JsonArray)
     private JSONArray arraySubject;
 
     private ArraySchema arraySchema;
@@ -30,6 +31,7 @@ class ArraySchemaValidatingVisitor extends Visitor {
     }
 
     @Override void visitArraySchema(ArraySchema arraySchema) {
+        // TODO: New API (JsonArray)
         if (owner.passesTypeCheck(JSONArray.class, arraySchema.requiresArray(), arraySchema.isNullable())) {
             this.arraySubject = (JSONArray) subject;
             this.subjectLength = arraySubject.length();

--- a/core/src/main/java/org/everit/json/schema/EnumSchema.java
+++ b/core/src/main/java/org/everit/json/schema/EnumSchema.java
@@ -18,10 +18,13 @@ import org.json.JSONObject;
 public class EnumSchema extends Schema {
 
     static Object toJavaValue(Object orig) {
+        // TODO: New API (JsonArray)
         if (orig instanceof JSONArray) {
             return ((JSONArray) orig).toList();
+        // TODO: New API (JsonObject)
         } else if (orig instanceof JSONObject) {
             return ((JSONObject) orig).toMap();
+        // TODO: New API (Null)
         } else if (orig == JSONObject.NULL) {
             return null;
         } else {

--- a/core/src/main/java/org/everit/json/schema/NumberSchema.java
+++ b/core/src/main/java/org/everit/json/schema/NumberSchema.java
@@ -206,7 +206,7 @@ public class NumberSchema extends Schema {
         try {
             writer.ifPresent("exclusiveMinimum", exclusiveMinimumLimit);
             writer.ifPresent("exclusiveMaximum", exclusiveMaximumLimit);
-        } catch (JSONException e) {
+        } catch (JSONException e) { // TODO: New API (JsonException)
             throw new IllegalStateException("overloaded use of exclusiveMinimum or exclusiveMaximum keyword");
         }
     }

--- a/core/src/main/java/org/everit/json/schema/ObjectComparator.java
+++ b/core/src/main/java/org/everit/json/schema/ObjectComparator.java
@@ -1,78 +1,29 @@
 package org.everit.json.schema;
 
-import java.util.Arrays;
-import java.util.Objects;
-
+import org.everit.json.schema.facade.Facade;
 import org.json.JSONArray;
-import org.json.JSONObject;
 
 /**
- * Deep-equals implementation on primitive wrappers, {@link JSONObject} and {@link JSONArray}.
+ * Deep-equals implementation on primitive wrappers,
+ * {@link org.everit.json.schema.facade.JsonObject} and
+ * {@link JSONArray}.
  */
+@Deprecated
 public final class ObjectComparator {
-
     /**
-     * Deep-equals implementation on primitive wrappers, {@link JSONObject} and {@link JSONArray}.
+     * Deep-equals implementation on primitive wrappers,
+     * {@link org.everit.json.schema.facade.JsonObject} and
+     * {@link JSONArray}.
      *
-     * @param obj1
-     *         the first object to be inspected
-     * @param obj2
-     *         the second object to be inspected
+     * @param obj1 the first object to be inspected
+     * @param obj2 the second object to be inspected
      * @return {@code true} if the two objects are equal, {@code false} otherwise
      */
     public static boolean deepEquals(Object obj1, Object obj2) {
-        if (obj1 instanceof JSONArray) {
-            if (!(obj2 instanceof JSONArray)) {
-                return false;
-            }
-            return deepEqualArrays((JSONArray) obj1, (JSONArray) obj2);
-        } else if (obj1 instanceof JSONObject) {
-            if (!(obj2 instanceof JSONObject)) {
-                return false;
-            }
-            return deepEqualObjects((JSONObject) obj1, (JSONObject) obj2);
-        }
-        return Objects.equals(obj1, obj2);
-    }
-
-    private static boolean deepEqualArrays(JSONArray arr1, JSONArray arr2) {
-        if (arr1.length() != arr2.length()) {
-            return false;
-        }
-        for (int i = 0; i < arr1.length(); ++i) {
-            if (!deepEquals(arr1.get(i), arr2.get(i))) {
-                return false;
-            }
-        }
-        return true;
-    }
-
-    private static String[] sortedNamesOf(JSONObject obj) {
-        String[] raw = JSONObject.getNames(obj);
-        if (raw == null) {
-            return null;
-        }
-        Arrays.sort(raw, String.CASE_INSENSITIVE_ORDER);
-        return raw;
-    }
-
-    private static boolean deepEqualObjects(JSONObject jsonObj1, JSONObject jsonObj2) {
-        String[] obj1Names = sortedNamesOf(jsonObj1);
-        if (!Arrays.equals(obj1Names, sortedNamesOf(jsonObj2))) {
-            return false;
-        }
-        if (obj1Names == null) {
-            return true;
-        }
-        for (String name : obj1Names) {
-            if (!deepEquals(jsonObj1.get(name), jsonObj2.get(name))) {
-                return false;
-            }
-        }
-        return true;
+        return Facade.getInstance().comparator()
+            .deepEquals(obj1, obj2);
     }
 
     private ObjectComparator() {
     }
-
 }

--- a/core/src/main/java/org/everit/json/schema/ObjectSchemaValidatingVisitor.java
+++ b/core/src/main/java/org/everit/json/schema/ObjectSchemaValidatingVisitor.java
@@ -14,6 +14,7 @@ class ObjectSchemaValidatingVisitor extends Visitor {
 
     private final Object subject;
 
+    // TODO: New API (JsonObject)
     private JSONObject objSubject;
 
     private ObjectSchema schema;
@@ -28,6 +29,7 @@ class ObjectSchemaValidatingVisitor extends Visitor {
     }
 
     @Override void visitObjectSchema(ObjectSchema objectSchema) {
+        // TODO: New API (JsonObject)
         if (owner.passesTypeCheck(JSONObject.class, objectSchema.requiresObject(), objectSchema.isNullable())) {
             objSubject = (JSONObject) subject;
             objectSize = objSubject.length();
@@ -129,6 +131,7 @@ class ObjectSchemaValidatingVisitor extends Visitor {
     }
 
     @Override void visitPatternPropertySchema(Regexp propertyNamePattern, Schema schema) {
+        // TODO: New API (JsonObject)
         String[] propNames = JSONObject.getNames(objSubject);
         if (propNames == null || propNames.length == 0) {
             return;

--- a/core/src/main/java/org/everit/json/schema/Schema.java
+++ b/core/src/main/java/org/everit/json/schema/Schema.java
@@ -3,8 +3,9 @@ package org.everit.json.schema;
 import java.io.StringWriter;
 import java.util.Objects;
 
+import org.everit.json.schema.facade.JsonWriter;
 import org.everit.json.schema.internal.JSONPrinter;
-import org.json.JSONWriter;
+import org.json.JSONPointer;
 
 /**
  * Superclass of all other schema validator classes of this package.
@@ -237,14 +238,14 @@ public abstract class Schema {
      * Describes the instance as a JSONObject to {@code writer}.
      * <p>
      * First it adds the {@code "title} , {@code "description"} and {@code "id"} properties then calls
-     * {@link #describePropertiesTo(JSONPrinter)}, which will add the subclass-specific properties.
+     * {@link #describePropertiesTo(JsonWriter)}, which will add the subclass-specific properties.
      * <p>
      * It is used by {@link #toString()} to serialize the schema instance into its JSON representation.
      *
      * @param writer
      *         it will receive the schema description
      */
-    public void describeTo(JSONPrinter writer) {
+    public void describeTo(JsonWriter writer) {
         writer.object();
         writer.ifPresent("title", title);
         writer.ifPresent("description", description);
@@ -257,16 +258,26 @@ public abstract class Schema {
         writer.endObject();
     }
 
+    @Deprecated // See new API
+    public void describeTo(JSONPrinter writer) {
+        this.describeTo((JsonWriter) writer);
+    }
+
     /**
      * Subclasses are supposed to override this method to describe the subclass-specific attributes.
-     * This method is called by {@link #describeTo(JSONPrinter)} after adding the generic properties if
+     * This method is called by {@link #describeTo(JsonWriter)} after adding the generic properties if
      * they are present ({@code id}, {@code title} and {@code description}). As a side effect,
-     * overriding subclasses don't have to open and close the object with {@link JSONWriter#object()}
-     * and {@link JSONWriter#endObject()}.
+     * overriding subclasses don't have to open and close the object with {@link JsonWriter#object()}
+     * and {@link JsonWriter#endObject()}.
      *
      * @param writer
      *         it will receive the schema description
      */
+    void describePropertiesTo(JsonWriter writer) {
+        this.describePropertiesTo(new JSONPrinter(writer));
+    }
+
+    @Deprecated // See new API
     void describePropertiesTo(JSONPrinter writer) {
 
     }

--- a/core/src/main/java/org/everit/json/schema/ValidationException.java
+++ b/core/src/main/java/org/everit/json/schema/ValidationException.java
@@ -8,6 +8,8 @@ import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
+import org.everit.json.schema.facade.Facade;
+import org.everit.json.schema.facade.JsonObject;
 import org.json.JSONArray;
 import org.json.JSONObject;
 
@@ -426,21 +428,27 @@ public class ValidationException extends RuntimeException {
      *
      * @return a JSON description of the validation error
      */
+    // TODO: New API (Easy)
+    @Deprecated
     public JSONObject toJSON() {
-        JSONObject rval = new JSONObject();
-        rval.put("keyword", keyword);
+        return toJson().unsafe(JSONObject.class);
+    }
+
+    public JsonObject toJson() {
+        JsonObject rval = Facade.getInstance().object();
+        rval.set("keyword", keyword);
         if (pointerToViolation == null) {
-            rval.put("pointerToViolation", JSONObject.NULL);
+            rval.set("pointerToViolation", Facade.getInstance().NULL());
         } else {
-            rval.put("pointerToViolation", getPointerToViolation());
+            rval.set("pointerToViolation", getPointerToViolation());
         }
-        rval.put("message", super.getMessage());
-        List<JSONObject> causeJsons = causingExceptions.stream()
-                .map(ValidationException::toJSON)
-                .collect(Collectors.toList());
-        rval.put("causingExceptions", new JSONArray(causeJsons));
+        rval.set("message", super.getMessage());
+        List<Object> causeJsons = causingExceptions.stream()
+            .map(ValidationException::toJson)
+            .collect(Collectors.toList());
+        rval.set("causingExceptions", new JSONArray(causeJsons));
         if (schemaLocation != null) {
-            rval.put("schemaLocation", schemaLocation);
+            rval.set("schemaLocation", schemaLocation);
         }
         return rval;
     }

--- a/core/src/main/java/org/everit/json/schema/facade/Facade.java
+++ b/core/src/main/java/org/everit/json/schema/facade/Facade.java
@@ -1,0 +1,54 @@
+package org.everit.json.schema.facade;
+
+import org.everit.json.schema.facade.orgjson.JsonOrg;
+
+import java.io.Writer;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.ServiceLoader;
+
+public final class Facade {
+    private static final ServiceLoader<FacadeImpl> LOADER = ServiceLoader.load(FacadeImpl.class);
+    private static FacadeImpl instance;
+
+    private Facade() { // Utility Class
+        throw new Error();
+    }
+
+    // TODO: Document
+    // Allows overriding when ServiceLoader is not feasible.
+    public static void setInstance(FacadeImpl instance) {
+        Facade.instance = instance;
+    }
+
+    public static FacadeImpl getInstance() {
+        if (instance == null) {
+            load();
+        }
+        return instance;
+    }
+
+    private static void load() {
+        LOADER.reload();
+        Iterator<FacadeImpl> it = LOADER.iterator();
+        if (!it.hasNext()) {
+            // TODO: Remove
+            instance = new JsonOrg();
+            return;
+            // throw new IllegalStateException("Missing Json Implementation. Are you sure it is on the classpath?");
+        }
+        instance = it.next();
+    }
+
+    public interface FacadeImpl {
+        Object NULL();
+
+        JsonObject object();
+
+        JsonArray array(Collection<Object> elements);
+
+        JsonWriter writer(Writer writer);
+
+        JsonComparator comparator();
+    }
+}

--- a/core/src/main/java/org/everit/json/schema/facade/JsonArray.java
+++ b/core/src/main/java/org/everit/json/schema/facade/JsonArray.java
@@ -1,0 +1,4 @@
+package org.everit.json.schema.facade;
+
+public interface JsonArray extends JsonElement {
+}

--- a/core/src/main/java/org/everit/json/schema/facade/JsonComparator.java
+++ b/core/src/main/java/org/everit/json/schema/facade/JsonComparator.java
@@ -1,0 +1,17 @@
+package org.everit.json.schema.facade;
+
+import org.json.JSONArray;
+
+/**
+ * Deep-equals implementation on primitive wrappers, {@link JsonObject} and {@link JSONArray}.
+ */
+public interface JsonComparator {
+    /**
+     * Deep-equals implementation on primitive wrappers, {@link JsonObject} and {@link JSONArray}.
+     *
+     * @param obj1 the first object to be inspected
+     * @param obj2 the second object to be inspected
+     * @return {@code true} if the two objects are equal, {@code false} otherwise
+     */
+    boolean deepEquals(Object obj1, Object obj2);
+}

--- a/core/src/main/java/org/everit/json/schema/facade/JsonElement.java
+++ b/core/src/main/java/org/everit/json/schema/facade/JsonElement.java
@@ -1,0 +1,17 @@
+package org.everit.json.schema.facade;
+
+public interface JsonElement {
+    // Turns this Element into an arbitrary Object. Mainly intended for backwards compatibility.
+    // May throw UnsupportedOperationException if Object type is not supported. E.g. Json Org expected but not provided
+    // Type may not be null => NPE
+    // Subclasses should call parent / interface
+    default <T> T unsafe(Class<T> type) {
+        throw new UnsupportedOperationException(
+            String.format(
+                "Representing '%s' as '%s' is not supported.\nPlease consult the documentation of your Facade",
+                this.getClass().getCanonicalName(),
+                type.getCanonicalName()
+            )
+        );
+    }
+}

--- a/core/src/main/java/org/everit/json/schema/facade/JsonObject.java
+++ b/core/src/main/java/org/everit/json/schema/facade/JsonObject.java
@@ -1,0 +1,5 @@
+package org.everit.json.schema.facade;
+
+public interface JsonObject extends JsonElement {
+    void set(String key, Object value);
+}

--- a/core/src/main/java/org/everit/json/schema/facade/JsonWriter.java
+++ b/core/src/main/java/org/everit/json/schema/facade/JsonWriter.java
@@ -1,0 +1,46 @@
+package org.everit.json.schema.facade;
+
+import org.everit.json.schema.Schema;
+
+import java.util.Map;
+
+public interface JsonWriter {
+    JsonWriter key(final String key);
+    JsonWriter value(final Object value);
+    JsonWriter object();
+    JsonWriter endObject();
+    JsonWriter array();
+    JsonWriter endArray();
+
+    default JsonWriter ifPresent(final String key, final Object value) {
+        if (value != null) {
+            key(key);
+            value(value);
+        }
+        return this;
+    }
+
+    default JsonWriter ifTrue(final String key, final Boolean value) {
+        if (value != null && value) {
+            key(key);
+            value(value);
+        }
+        return this;
+    }
+
+    default void ifFalse(String key, Boolean value) {
+        if (value != null && !value) {
+            key(key);
+            value(value);
+        }
+    }
+
+    default <K> void printSchemaMap(Map<K, Schema> input) {
+        object();
+        input.entrySet().forEach(entry -> {
+            key(entry.getKey().toString());
+            entry.getValue().describeTo(this);
+        });
+        endObject();
+    }
+}

--- a/core/src/main/java/org/everit/json/schema/facade/orgjson/Array.java
+++ b/core/src/main/java/org/everit/json/schema/facade/orgjson/Array.java
@@ -1,0 +1,20 @@
+package org.everit.json.schema.facade.orgjson;
+
+import org.everit.json.schema.facade.JsonArray;
+import org.json.JSONArray;
+
+import java.util.Collection;
+
+final class Array extends JSONArray implements JsonArray {
+    Array(Collection<Object> elements) {
+        super(elements);
+    }
+
+    @Override
+    public <T> T unsafe(Class<T> type) {
+        if (type.isInstance(this)) {
+            return type.cast(this);
+        }
+        return JsonArray.super.unsafe(type);
+    }
+}

--- a/core/src/main/java/org/everit/json/schema/facade/orgjson/Comparator.java
+++ b/core/src/main/java/org/everit/json/schema/facade/orgjson/Comparator.java
@@ -1,0 +1,66 @@
+package org.everit.json.schema.facade.orgjson;
+
+import org.everit.json.schema.facade.JsonComparator;
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+import java.util.Arrays;
+import java.util.Objects;
+
+// TODO: New API (JsonObject)
+// TODO: New API (JsonArray)
+// Its fine to use JSON Array Here for now though, as they are extended anyway.
+final class Comparator implements JsonComparator {
+    @Override
+    public boolean deepEquals(Object obj1, Object obj2) {
+        if (obj1 instanceof JSONArray) {
+            if (!(obj2 instanceof JSONArray)) {
+                return false;
+            }
+            return deepEqualArrays((JSONArray) obj1, (JSONArray) obj2);
+        } else if (obj1 instanceof JSONObject) {
+            if (!(obj2 instanceof JSONObject)) {
+                return false;
+            }
+            return deepEqualObjects((JSONObject) obj1, (JSONObject) obj2);
+        }
+        return Objects.equals(obj1, obj2);
+    }
+
+    private boolean deepEqualArrays(JSONArray arr1, JSONArray arr2) {
+        if (arr1.length() != arr2.length()) {
+            return false;
+        }
+        for (int i = 0; i < arr1.length(); ++i) {
+            if (!deepEquals(arr1.get(i), arr2.get(i))) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private String[] sortedNamesOf(JSONObject obj) {
+        String[] raw = JSONObject.getNames(obj);
+        if (raw == null) {
+            return null;
+        }
+        Arrays.sort(raw, String.CASE_INSENSITIVE_ORDER);
+        return raw;
+    }
+
+    private boolean deepEqualObjects(JSONObject jsonObj1, JSONObject jsonObj2) {
+        String[] obj1Names = sortedNamesOf(jsonObj1);
+        if (!Arrays.equals(obj1Names, sortedNamesOf(jsonObj2))) {
+            return false;
+        }
+        if (obj1Names == null) {
+            return true;
+        }
+        for (String name : obj1Names) {
+            if (!deepEquals(jsonObj1.get(name), jsonObj2.get(name))) {
+                return false;
+            }
+        }
+        return true;
+    }
+}

--- a/core/src/main/java/org/everit/json/schema/facade/orgjson/JsonOrg.java
+++ b/core/src/main/java/org/everit/json/schema/facade/orgjson/JsonOrg.java
@@ -1,0 +1,41 @@
+package org.everit.json.schema.facade.orgjson;
+
+import org.everit.json.schema.facade.Facade;
+import org.everit.json.schema.facade.JsonArray;
+import org.everit.json.schema.facade.JsonComparator;
+import org.everit.json.schema.facade.JsonObject;
+import org.everit.json.schema.facade.JsonWriter;
+import org.json.JSONObject;
+
+import java.io.Writer;
+import java.util.Collection;
+
+public final class JsonOrg implements Facade.FacadeImpl {
+    private static final JsonComparator COMPARATOR = new Comparator();
+
+    @Override
+    public Object NULL() {
+        return JSONObject.NULL;
+    }
+
+    @Override
+    public JsonObject object() {
+        return new Obj();
+    }
+
+    @Override
+    public JsonArray array(Collection<Object> elements) {
+        return new Array(elements);
+    }
+
+    @Override
+    public JsonWriter writer(Writer writer) {
+        return null;
+    }
+
+    @Override
+    public JsonComparator comparator() {
+        return COMPARATOR;
+    }
+
+}

--- a/core/src/main/java/org/everit/json/schema/facade/orgjson/Obj.java
+++ b/core/src/main/java/org/everit/json/schema/facade/orgjson/Obj.java
@@ -1,0 +1,19 @@
+package org.everit.json.schema.facade.orgjson;
+
+import org.everit.json.schema.facade.JsonObject;
+import org.json.JSONObject;
+
+final class Obj extends JSONObject implements JsonObject {
+    @Override
+    public void set(String key, Object value) {
+        put(key, value);
+    }
+
+    @Override
+    public <T> T unsafe(Class<T> type) {
+        if (type.isInstance(this)) {
+            return type.cast(this);
+        }
+        return JsonObject.super.unsafe(type);
+    }
+}

--- a/core/src/main/java/org/everit/json/schema/internal/JSONPrinter.java
+++ b/core/src/main/java/org/everit/json/schema/internal/JSONPrinter.java
@@ -1,6 +1,7 @@
 package org.everit.json.schema.internal;
 
 import org.everit.json.schema.Schema;
+import org.everit.json.schema.facade.JsonWriter;
 import org.json.JSONWriter;
 
 import java.io.Writer;
@@ -8,15 +9,20 @@ import java.util.Map;
 
 import static java.util.Objects.requireNonNull;
 
-public class JSONPrinter {
-
-    private final JSONWriter writer;
+@Deprecated // TODO: Document: use new API, to be removed in the future
+// TODO: Move to own maven artifact (with json org dependency)
+public class JSONPrinter implements JsonWriter {
+    private final JsonWriter writer;
 
     public JSONPrinter(final Writer writer) {
         this(new JSONWriter(writer));
     }
 
     public JSONPrinter(final JSONWriter writer) {
+        this(new Wrapper(writer));
+    }
+
+    public JSONPrinter(final JsonWriter writer) {
         this.writer = requireNonNull(writer, "writer cannot be null");
     }
 
@@ -41,18 +47,12 @@ public class JSONPrinter {
     }
 
     public JSONPrinter ifPresent(final String key, final Object value) {
-        if (value != null) {
-            key(key);
-            value(value);
-        }
+        JsonWriter.super.ifPresent(key, value);
         return this;
     }
 
     public JSONPrinter ifTrue(final String key, final Boolean value) {
-        if (value != null && value) {
-            key(key);
-            value(value);
-        }
+        JsonWriter.super.ifTrue(key, value);
         return this;
     }
 
@@ -66,19 +66,47 @@ public class JSONPrinter {
         return this;
     }
 
-    public void ifFalse(String key, Boolean value) {
-        if (value != null && !value) {
-            writer.key(key);
-            writer.value(value);
-        }
-    }
+    private static class Wrapper implements JsonWriter {
+        private final JSONWriter writer;
 
-    public <K> void printSchemaMap(Map<K, Schema> input) {
-        object();
-        input.entrySet().forEach(entry -> {
-            key(entry.getKey().toString());
-            entry.getValue().describeTo(this);
-        });
-        endObject();
+        private Wrapper(JSONWriter writer) {
+            this.writer = writer;
+        }
+
+        @Override
+        public JsonWriter key(String key) {
+            writer.key(key);
+            return this;
+        }
+
+        @Override
+        public JsonWriter value(Object value) {
+            writer.value(value);
+            return this;
+        }
+
+        @Override
+        public JsonWriter object() {
+            writer.object();
+            return this;
+        }
+
+        @Override
+        public JsonWriter endObject() {
+            writer.endObject();
+            return this;
+        }
+
+        @Override
+        public JsonWriter array() {
+            writer.array();
+            return this;
+        }
+
+        @Override
+        public JsonWriter endArray() {
+            writer.endArray();
+            return this;
+        }
     }
 }

--- a/core/src/main/java/org/everit/json/schema/internal/JsonPointerFormatValidator.java
+++ b/core/src/main/java/org/everit/json/schema/internal/JsonPointerFormatValidator.java
@@ -14,6 +14,7 @@ public class JsonPointerFormatValidator implements FormatValidator {
             return Optional.empty();
         }
         try {
+            // TODO: New API (JsonPointer)
             new JSONPointer(subject);
             if (subject.startsWith("#")) {
                 return failure(subject);

--- a/core/src/main/java/org/everit/json/schema/internal/RelativeJsonPointerFormatValidator.java
+++ b/core/src/main/java/org/everit/json/schema/internal/RelativeJsonPointerFormatValidator.java
@@ -95,6 +95,7 @@ public class RelativeJsonPointerFormatValidator implements FormatValidator {
                 fail();
             }
             try {
+                // TODO: New API (JsonPointer)
                 new JSONPointer(pointer);
             } catch (IllegalArgumentException e) {
                 fail();

--- a/core/src/main/java/org/everit/json/schema/loader/JsonPointerEvaluator.java
+++ b/core/src/main/java/org/everit/json/schema/loader/JsonPointerEvaluator.java
@@ -82,6 +82,8 @@ class JsonPointerEvaluator {
                 strBuilder.append(line);
             }
             resp = strBuilder.toString();
+            // TODO: New API (JsonObject)
+            // TODO: New API (JsonTokener)
             return new JsonObject(new JSONObject(new JSONTokener(resp)).toMap());
         } catch (IOException e) {
             throw new UncheckedIOException(e);
@@ -159,6 +161,7 @@ class JsonPointerEvaluator {
                 result = queryFrom(document, tokens);
             }
             return new QueryResult(document, result);
+        // TODO: New API (JsonPointerException)
         } catch (JSONPointerException e) {
             throw new SchemaException(e.getMessage());
         }

--- a/core/src/main/java/org/everit/json/schema/loader/JsonValue.java
+++ b/core/src/main/java/org/everit/json/schema/loader/JsonValue.java
@@ -107,9 +107,11 @@ class JsonValue {
             return new JsonObject((Map<String, Object>) obj);
         } else if (obj instanceof List) {
             return new JsonArray((List<Object>) obj);
+        // TODO: New API (JsonObject)
         } else if (obj instanceof JSONObject) {
             JSONObject jo = (JSONObject) obj;
             return new JsonObject(jo.toMap());
+        // TODO: New API (JsonArray)
         } else if (obj instanceof JSONArray) {
             JSONArray arr = (JSONArray) obj;
             return new JsonArray(arr.toList());
@@ -236,13 +238,16 @@ class JsonValue {
     }
 
     protected static Object deepToOrgJson(JsonValue v) {
+        // TODO: New API (Null)
         if (v.unwrap() == null) {
             return JSONObject.NULL;
         } if (v instanceof JsonObject) {
+            // TODO: New API (JsonObject)
             JSONObject obj = new JSONObject();
             ((JsonObject)v).forEach((key, value) -> obj.put(key, deepToOrgJson(value)));
             return obj;
         } else if (v instanceof JsonArray) {
+            // TODO: New API (JsonArray)
             JSONArray array = new JSONArray();
             ((JsonArray)v).forEach((index, value) -> array.put(deepToOrgJson(value)));
             return array;

--- a/core/src/main/java/org/everit/json/schema/loader/LoadingState.java
+++ b/core/src/main/java/org/everit/json/schema/loader/LoadingState.java
@@ -143,6 +143,7 @@ class LoadingState {
         return rootSchemaJson.requireObject();
     }
 
+    // TODO: New API (JsonPointer)
     String locationOfCurrentObj() {
         return new JSONPointer(pointerToCurrentObj).toURIFragment();
     }

--- a/core/src/main/java/org/everit/json/schema/loader/ReferenceLookup.java
+++ b/core/src/main/java/org/everit/json/schema/loader/ReferenceLookup.java
@@ -24,6 +24,7 @@ class ReferenceLookup {
      * parameter is an empty object).
      */
     @Deprecated
+    // TODO: New API (JsonObject)
     static JSONObject extend(final JSONObject additional, final JSONObject original) {
         return new JSONObject(extend(additional.toMap(), original.toMap()));
     }

--- a/core/src/main/java/org/everit/json/schema/loader/SchemaLoader.java
+++ b/core/src/main/java/org/everit/json/schema/loader/SchemaLoader.java
@@ -36,7 +36,7 @@ import org.json.JSONPointer;
  * Loads a JSON schema's JSON representation into schema validator instances.
  */
 public class SchemaLoader {
-
+    // TODO: New API (JsonObject)
     static JSONObject toOrgJSONObject(JsonObject value) {
         return new JSONObject(value.toMap());
     }
@@ -143,6 +143,7 @@ public class SchemaLoader {
         }
 
         @Deprecated
+        // TODO: New API (JsonObject)
         public JSONObject getRootSchemaJson() {
             return new JSONObject((Map<String, Object>) (rootSchemaJson == null ? schemaJson : rootSchemaJson));
         }
@@ -188,6 +189,7 @@ public class SchemaLoader {
         }
 
         public SchemaLoaderBuilder schemaJson(Object schema) {
+            // TODO: New API (JsonObject)
             if (schema instanceof JSONObject) {
                 schema = (((JSONObject) schema).toMap());
             }
@@ -241,6 +243,7 @@ public class SchemaLoader {
      *         the JSON representation of the schema.
      * @return the schema validator object
      */
+    // TODO: New API (JsonObject)
     public static Schema load(final JSONObject schemaJson) {
         return SchemaLoader.load(schemaJson, new DefaultSchemaClient());
     }
@@ -254,6 +257,7 @@ public class SchemaLoader {
      *         the HTTP client to be used for resolving remote JSON references.
      * @return the created schema
      */
+    // TODO: New API (JsonObject)
     public static Schema load(final JSONObject schemaJson, final SchemaClient httpClient) {
         SchemaLoader loader = builder()
                 .schemaJson(schemaJson)
@@ -393,6 +397,7 @@ public class SchemaLoader {
         if (config.useDefaults) {
             ls.schemaJson().maybe("default").map(JsonValue::deepToOrgJson).ifPresent(builder::defaultValue);
         }
+        // TODO: New API (JsonPointer)
         builder.schemaLocation(new JSONPointer(ls.pointerToCurrentObj).toURIFragment());
     }
 

--- a/core/src/main/java/org/everit/json/schema/loader/internal/JSONPointer.java
+++ b/core/src/main/java/org/everit/json/schema/loader/internal/JSONPointer.java
@@ -28,8 +28,10 @@ public class JSONPointer {
      */
     public static class QueryResult {
 
+        // TODO: New API (JsonObject)
         private final JSONObject containingDocument;
 
+        // TODO: New API (JsonObject)
         private final JSONObject queryResult;
 
         /**
@@ -65,6 +67,7 @@ public class JSONPointer {
 
     }
 
+    // TODO: New API (JsonObject)
     private static JSONObject executeWith(final SchemaClient client, final String url) {
         String resp = null;
         BufferedReader buffReader = null;
@@ -99,6 +102,7 @@ public class JSONPointer {
     }
 
     @Deprecated
+    // TODO: New API (JsonObject)
     public static final JSONPointer forDocument(final JSONObject document, final String fragment) {
         return new JSONPointer(() -> document, fragment);
     }

--- a/core/src/main/java/org/everit/json/schema/loader/internal/TypeBasedMultiplexer.java
+++ b/core/src/main/java/org/everit/json/schema/loader/internal/TypeBasedMultiplexer.java
@@ -57,6 +57,7 @@ public class TypeBasedMultiplexer {
          */
         @Override
         public TypeBasedMultiplexer then(final Consumer<JSONObject> consumer) {
+            // TODO: New API (JsonObject)
             Consumer<JSONObject> wrapperConsumer = obj -> {
                 if (obj.has("id") && obj.get("id") instanceof String) {
                     URI origId = id;
@@ -195,6 +196,7 @@ public class TypeBasedMultiplexer {
      *         {@code obj}'s class against {@link JSONObject}.
      */
     public <E> OnTypeConsumer<E> ifIs(final Class<E> predicateClass) {
+        // TODO: New API (JsonObject)
         if (predicateClass == JSONObject.class) {
             throw new IllegalArgumentException("use ifObject() instead");
         }
@@ -207,6 +209,7 @@ public class TypeBasedMultiplexer {
      * @return an {@code OnTypeConsumer} implementation to be used to set the action performed if
      * {@code obj} is a JSONObject instance.
      */
+    // TODO: New API (JsonObject)
     public OnTypeConsumer<JSONObject> ifObject() {
         return new IdModifyingTypeConsumerImpl(JSONObject.class);
     }


### PR DESCRIPTION
This PR should not be merged as is and is simply a basic design that could be leveraged in the future. I did not document alot of the new functions, because most of them simply wrap the already existing methods / refactor them into new interfaces. This would allow to swap between implementations easily.

This PR is directly in contrast to #190 due to the nature of this PR. While i agree, that supporting Jackson is a good thing, i would kindly disagree, to simply switch the whole code base into a new model that is not backed by any standard (Obligatory [XKCD](https://xkcd.com/927/)).

See #37 #189 for more context to this issue.