### PR TITLE
Issue #231 iri fails to validate invalid values

### DIFF
--- a/tests/src/test/resources/org/everit/json/schema/issues/issue231/schema.json
+++ b/tests/src/test/resources/org/everit/json/schema/issues/issue231/schema.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "type" : "object",
+  "properties" : {
+    "history" : {"$ref" : "#/definitions/History" }
+  },
+  "required": ["history"],
+  "definitions" : {
+    "when" : {
+      "type" : "string",
+      "format": "date-time"
+    },
+    "who": {
+      "type": "string",
+      "format": "iri",
+      "$comment": "if the format is uri, it works as expected"
+    },
+    "History" : {
+      "type" : "object",
+      "properties" : {
+        "when" : {"$ref" : "#/definitions/when"},
+        "who" : {
+          "$ref": "#/definitions/who"
+        },
+        "what": {
+          "type": "string"
+        }
+      },
+      "required": ["who", "when", "what"],
+      "additionalProperties": false
+    }
+  }
+}

--- a/tests/src/test/resources/org/everit/json/schema/issues/issue231/subject-invalid.json
+++ b/tests/src/test/resources/org/everit/json/schema/issues/issue231/subject-invalid.json
@@ -1,0 +1,7 @@
+{
+  "history" : {
+    "who": "someone",
+    "when": "2017-09-23T20:21:34Z",
+    "what": "did wonders"
+  }
+}

--- a/tests/src/test/resources/org/everit/json/schema/issues/issue231/subject-valid.json
+++ b/tests/src/test/resources/org/everit/json/schema/issues/issue231/subject-valid.json
@@ -1,0 +1,8 @@
+{
+  "history" : {
+    "who": "http://example.com/person/1",
+    "when": "2017-09-23T20:21:34Z",
+    "what": "did wonders"
+  }
+}
+


### PR DESCRIPTION
A simple string IRI value is recognised as valid, which should not be the case.
Whereas the same is rightly classified as invalid if the format is URI (instead of IRI).
