### PR TITLE
Publish sources jar and javadoc jar

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -150,6 +150,30 @@
                     <autoReleaseAfterClose>true</autoReleaseAfterClose>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>attach-sources</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>attach-javadocs</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
     <dependencies>


### PR DESCRIPTION
Currently, IntelliJ and other IDEs aren't able to automatically jump to source or documentation for this library, since those jars aren't published.

We should get a nice developer experience improvement by providing these jars. This PR follows the example plugin configuration in https://github.com/jitpack/maven-simple