### PR TITLE
Add Schema validation path traceability

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -21,7 +21,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.everit.json</groupId>
     <artifactId>org.everit.json.schema</artifactId>
-    <version>0.0.0-develop</version>
+    <version>2.0.0</version>
     <packaging>bundle</packaging>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/core/src/main/java/org/everit/json/schema/ArraySchema.java
+++ b/core/src/main/java/org/everit/json/schema/ArraySchema.java
@@ -236,8 +236,8 @@ public class ArraySchema extends Schema {
         }
     }
 
-    @Override void accept(Visitor visitor) {
-        visitor.visitArraySchema(this);
+    @Override void accept(Visitor visitor, List<String> path) {
+        visitor.visitArraySchema(this, path);
     }
 
     @Override

--- a/core/src/main/java/org/everit/json/schema/ArraySchemaValidatingVisitor.java
+++ b/core/src/main/java/org/everit/json/schema/ArraySchemaValidatingVisitor.java
@@ -9,7 +9,9 @@ import java.util.List;
 import java.util.Optional;
 import java.util.function.IntFunction;
 import java.util.stream.IntStream;
+import java.util.stream.Stream;
 
+import java.util.List;
 import org.json.JSONArray;
 
 class ArraySchemaValidatingVisitor extends Visitor {
@@ -29,12 +31,12 @@ class ArraySchemaValidatingVisitor extends Visitor {
         this.owner = requireNonNull(owner, "owner cannot be null");
     }
 
-    @Override void visitArraySchema(ArraySchema arraySchema) {
+    @Override void visitArraySchema(ArraySchema arraySchema, List<String> path) {
         if (owner.passesTypeCheck(JSONArray.class, arraySchema.requiresArray(), arraySchema.isNullable())) {
             this.arraySubject = (JSONArray) subject;
             this.subjectLength = arraySubject.length();
             this.arraySchema = arraySchema;
-            super.visitArraySchema(arraySchema);
+            super.visitArraySchema(arraySchema, path);
         }
     }
 
@@ -67,19 +69,19 @@ class ArraySchemaValidatingVisitor extends Visitor {
         }
     }
 
-    @Override void visitAllItemSchema(Schema allItemSchema) {
+    @Override void visitAllItemSchema(Schema allItemSchema, List<String> path) {
         if (allItemSchema != null) {
-            validateItemsAgainstSchema(IntStream.range(0, subjectLength), allItemSchema);
+            validateItemsAgainstSchema(IntStream.range(0, subjectLength), allItemSchema, path);
         }
     }
 
-    @Override void visitItemSchema(int index, Schema itemSchema) {
+    @Override void visitItemSchema(int index, Schema itemSchema, List<String> path) {
         if (index >= subjectLength) {
             return;
         }
         Object subject = arraySubject.get(index);
         String idx = String.valueOf(index);
-        ifFails(itemSchema, subject)
+        ifFails(itemSchema, subject, path)
                 .map(exc -> exc.prepend(idx))
                 .ifPresent(owner::failure);
     }
@@ -92,37 +94,37 @@ class ArraySchemaValidatingVisitor extends Visitor {
         }
     }
 
-    @Override void visitSchemaOfAdditionalItems(Schema schemaOfAdditionalItems) {
+    @Override void visitSchemaOfAdditionalItems(Schema schemaOfAdditionalItems, List<String> path) {
         if (schemaOfAdditionalItems == null) {
             return;
         }
         int validationFrom = Math.min(subjectLength, arraySchema.getItemSchemas().size());
-        validateItemsAgainstSchema(IntStream.range(validationFrom, subjectLength), schemaOfAdditionalItems);
+        validateItemsAgainstSchema(IntStream.range(validationFrom, subjectLength), schemaOfAdditionalItems, path);
     }
 
-    private void validateItemsAgainstSchema(IntStream indices, Schema schema) {
-        validateItemsAgainstSchema(indices, i -> schema);
+    private void validateItemsAgainstSchema(IntStream indices, Schema schema, List<String> path) {
+        validateItemsAgainstSchema(indices, i -> schema, path);
     }
 
-    private void validateItemsAgainstSchema(IntStream indices, IntFunction<Schema> schemaForIndex) {
+    private void validateItemsAgainstSchema(IntStream indices, IntFunction<Schema> schemaForIndex, List<String> path) {
         for (int i : indices.toArray()) {
             String copyOfI = String.valueOf(i); // i is not effectively final so we copy it
-            ifFails(schemaForIndex.apply(i), arraySubject.get(i))
+            ifFails(schemaForIndex.apply(i), arraySubject.get(i), appendPath(path, i))
                     .map(exc -> exc.prepend(copyOfI))
                     .ifPresent(owner::failure);
         }
     }
 
-    private Optional<ValidationException> ifFails(Schema schema, Object input) {
-        return Optional.ofNullable(owner.getFailureOfSchema(schema, input));
+    private Optional<ValidationException> ifFails(Schema schema, Object input, List<String> path) {
+        return Optional.ofNullable(owner.getFailureOfSchema(schema, input, path));
     }
 
-    @Override void visitContainedItemSchema(Schema containedItemSchema) {
+    @Override void visitContainedItemSchema(Schema containedItemSchema, List<String> path) {
         if (containedItemSchema == null) {
             return;
         }
         for (int i = 0; i < arraySubject.length(); i++) {
-            Optional<ValidationException> exception = ifFails(containedItemSchema, arraySubject.get(i));
+            Optional<ValidationException> exception = ifFails(containedItemSchema, arraySubject.get(i), appendPath(path, i));
             if (!exception.isPresent()) {
                 return;
             }

--- a/core/src/main/java/org/everit/json/schema/ArraySchemaValidatingVisitor.java
+++ b/core/src/main/java/org/everit/json/schema/ArraySchemaValidatingVisitor.java
@@ -2,16 +2,13 @@ package org.everit.json.schema;
 
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
-
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.IntFunction;
 import java.util.stream.IntStream;
-import java.util.stream.Stream;
 
-import java.util.List;
 import org.json.JSONArray;
 
 class ArraySchemaValidatingVisitor extends Visitor {

--- a/core/src/main/java/org/everit/json/schema/BooleanSchema.java
+++ b/core/src/main/java/org/everit/json/schema/BooleanSchema.java
@@ -1,6 +1,9 @@
 package org.everit.json.schema;
 
+import java.util.List;
 import org.everit.json.schema.internal.JSONPrinter;
+
+import java.util.stream.Stream;
 
 /**
  * Boolean schema validator.
@@ -48,7 +51,7 @@ public class BooleanSchema extends Schema {
         }
     }
 
-    @Override void accept(Visitor visitor) {
+    @Override void accept(Visitor visitor, List<String> path) {
         visitor.visitBooleanSchema(this);
     }
 

--- a/core/src/main/java/org/everit/json/schema/BooleanSchema.java
+++ b/core/src/main/java/org/everit/json/schema/BooleanSchema.java
@@ -3,7 +3,6 @@ package org.everit.json.schema;
 import java.util.List;
 import org.everit.json.schema.internal.JSONPrinter;
 
-import java.util.stream.Stream;
 
 /**
  * Boolean schema validator.

--- a/core/src/main/java/org/everit/json/schema/CombinedSchema.java
+++ b/core/src/main/java/org/everit/json/schema/CombinedSchema.java
@@ -7,7 +7,9 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
+import java.util.stream.Stream;
 
+import java.util.List;
 import org.everit.json.schema.internal.JSONPrinter;
 
 /**
@@ -180,8 +182,8 @@ public class CombinedSchema extends Schema {
         return subschemas;
     }
 
-    @Override void accept(Visitor visitor) {
-        visitor.visitCombinedSchema(this);
+    @Override void accept(Visitor visitor, List<String> path) {
+        visitor.visitCombinedSchema(this, path);
     }
 
     @Override

--- a/core/src/main/java/org/everit/json/schema/CombinedSchema.java
+++ b/core/src/main/java/org/everit/json/schema/CombinedSchema.java
@@ -7,9 +7,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
-import java.util.stream.Stream;
 
-import java.util.List;
 import org.everit.json.schema.internal.JSONPrinter;
 
 /**

--- a/core/src/main/java/org/everit/json/schema/ConditionalSchema.java
+++ b/core/src/main/java/org/everit/json/schema/ConditionalSchema.java
@@ -1,7 +1,9 @@
 package org.everit.json.schema;
 
 import java.util.Optional;
+import java.util.stream.Stream;
 
+import java.util.List;
 import org.everit.json.schema.internal.JSONPrinter;
 
 /**
@@ -66,8 +68,8 @@ public class ConditionalSchema extends Schema {
     }
 
     @Override
-    void accept(Visitor visitor) {
-        visitor.visitConditionalSchema(this);
+    void accept(Visitor visitor, List<String> path) {
+        visitor.visitConditionalSchema(this, path);
     }
 
     @Override void describePropertiesTo(JSONPrinter writer) {

--- a/core/src/main/java/org/everit/json/schema/ConditionalSchema.java
+++ b/core/src/main/java/org/everit/json/schema/ConditionalSchema.java
@@ -1,8 +1,6 @@
 package org.everit.json.schema;
 
 import java.util.Optional;
-import java.util.stream.Stream;
-
 import java.util.List;
 import org.everit.json.schema.internal.JSONPrinter;
 

--- a/core/src/main/java/org/everit/json/schema/ConditionalSchemaValidatingVisitor.java
+++ b/core/src/main/java/org/everit/json/schema/ConditionalSchemaValidatingVisitor.java
@@ -10,6 +10,8 @@ import org.everit.json.schema.event.ConditionalSchemaMatchEvent;
 import org.everit.json.schema.event.ConditionalSchemaMismatchEvent;
 import org.everit.json.schema.event.ConditionalSchemaValidationEvent;
 
+import java.util.List;
+
 class ConditionalSchemaValidatingVisitor extends Visitor {
 
     private final Object subject;
@@ -26,19 +28,19 @@ class ConditionalSchemaValidatingVisitor extends Visitor {
     }
 
     @Override
-    void visitConditionalSchema(ConditionalSchema conditionalSchema) {
+    void visitConditionalSchema(ConditionalSchema conditionalSchema, List<String> path) {
         this.conditionalSchema = conditionalSchema;
         if (!conditionalSchema.getIfSchema().isPresent() ||
                 (!conditionalSchema.getThenSchema().isPresent() && !conditionalSchema.getElseSchema().isPresent())) {
             return;
         }
-        super.visitConditionalSchema(conditionalSchema);
+        super.visitConditionalSchema(conditionalSchema, path);
     }
 
     @Override
-    void visitIfSchema(Schema ifSchema) {
+    void visitIfSchema(Schema ifSchema, List<String> path) {
         if (conditionalSchema.getIfSchema().isPresent()) {
-            ifSchemaException = owner.getFailureOfSchema(ifSchema, subject);
+            ifSchemaException = owner.getFailureOfSchema(ifSchema, subject, path);
             if (ifSchemaException == null) {
                 owner.validationListener.ifSchemaMatch(createMatchEvent(IF));
             } else {
@@ -48,9 +50,9 @@ class ConditionalSchemaValidatingVisitor extends Visitor {
     }
 
     @Override
-    void visitThenSchema(Schema thenSchema) {
+    void visitThenSchema(Schema thenSchema, List<String> path) {
         if (ifSchemaException == null) {
-            ValidationException thenSchemaException = owner.getFailureOfSchema(thenSchema, subject);
+            ValidationException thenSchemaException = owner.getFailureOfSchema(thenSchema, subject, path);
             if (thenSchemaException != null) {
                 ValidationException failure = new ValidationException(conditionalSchema,
                         new StringBuilder(new StringBuilder("#")),
@@ -68,9 +70,9 @@ class ConditionalSchemaValidatingVisitor extends Visitor {
     }
 
     @Override
-    void visitElseSchema(Schema elseSchema) {
+    void visitElseSchema(Schema elseSchema, List<String> path) {
         if (ifSchemaException != null) {
-            ValidationException elseSchemaException = owner.getFailureOfSchema(elseSchema, subject);
+            ValidationException elseSchemaException = owner.getFailureOfSchema(elseSchema, subject, path);
             if (elseSchemaException != null) {
                 ValidationException failure = new ValidationException(conditionalSchema,
                         new StringBuilder(new StringBuilder("#")),

--- a/core/src/main/java/org/everit/json/schema/ConstSchema.java
+++ b/core/src/main/java/org/everit/json/schema/ConstSchema.java
@@ -2,7 +2,10 @@ package org.everit.json.schema;
 
 import static org.everit.json.schema.EnumSchema.toJavaValue;
 
+import java.util.List;
 import org.everit.json.schema.internal.JSONPrinter;
+
+import java.util.stream.Stream;
 
 public class ConstSchema extends Schema {
 
@@ -37,6 +40,10 @@ public class ConstSchema extends Schema {
     }
 
     @Override void accept(Visitor visitor) {
+        visitor.visitConstSchema(this);
+    }
+
+    @Override void accept(Visitor visitor, List<String> path) {
         visitor.visitConstSchema(this);
     }
 

--- a/core/src/main/java/org/everit/json/schema/ConstSchema.java
+++ b/core/src/main/java/org/everit/json/schema/ConstSchema.java
@@ -5,8 +5,6 @@ import static org.everit.json.schema.EnumSchema.toJavaValue;
 import java.util.List;
 import org.everit.json.schema.internal.JSONPrinter;
 
-import java.util.stream.Stream;
-
 public class ConstSchema extends Schema {
 
     public static class ConstSchemaBuilder extends Schema.Builder<ConstSchema> {

--- a/core/src/main/java/org/everit/json/schema/EmptySchema.java
+++ b/core/src/main/java/org/everit/json/schema/EmptySchema.java
@@ -1,5 +1,9 @@
 package org.everit.json.schema;
 
+import java.util.List;
+
+import java.util.stream.Stream;
+
 /**
  * A schema not specifying any restrictions, ie. accepting any values.
  */
@@ -28,6 +32,10 @@ public class EmptySchema extends Schema {
     }
 
     @Override void accept(Visitor visitor) {
+        visitor.visitEmptySchema();
+    }
+
+    @Override void accept(Visitor visitor, List<String> path) {
         visitor.visitEmptySchema();
     }
 

--- a/core/src/main/java/org/everit/json/schema/EmptySchema.java
+++ b/core/src/main/java/org/everit/json/schema/EmptySchema.java
@@ -2,8 +2,6 @@ package org.everit.json.schema;
 
 import java.util.List;
 
-import java.util.stream.Stream;
-
 /**
  * A schema not specifying any restrictions, ie. accepting any values.
  */

--- a/core/src/main/java/org/everit/json/schema/EnumSchema.java
+++ b/core/src/main/java/org/everit/json/schema/EnumSchema.java
@@ -9,7 +9,9 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
+import java.util.List;
 import org.everit.json.schema.internal.JSONPrinter;
 import org.everit.json.schema.loader.OrgJsonUtil;
 import org.json.JSONArray;
@@ -112,6 +114,10 @@ public class EnumSchema extends Schema {
     }
 
     @Override public void accept(Visitor visitor) {
+        visitor.visitEnumSchema(this);
+    }
+
+    @Override public void accept(Visitor visitor, List<String> path) {
         visitor.visitEnumSchema(this);
     }
 

--- a/core/src/main/java/org/everit/json/schema/EnumSchema.java
+++ b/core/src/main/java/org/everit/json/schema/EnumSchema.java
@@ -9,9 +9,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
-import java.util.List;
 import org.everit.json.schema.internal.JSONPrinter;
 import org.everit.json.schema.loader.OrgJsonUtil;
 import org.json.JSONArray;

--- a/core/src/main/java/org/everit/json/schema/FalseSchema.java
+++ b/core/src/main/java/org/everit/json/schema/FalseSchema.java
@@ -3,7 +3,6 @@ package org.everit.json.schema;
 import java.util.List;
 import org.everit.json.schema.internal.JSONPrinter;
 
-import java.util.stream.Stream;
 
 /**
  * @author erosb

--- a/core/src/main/java/org/everit/json/schema/FalseSchema.java
+++ b/core/src/main/java/org/everit/json/schema/FalseSchema.java
@@ -1,6 +1,9 @@
 package org.everit.json.schema;
 
+import java.util.List;
 import org.everit.json.schema.internal.JSONPrinter;
+
+import java.util.stream.Stream;
 
 /**
  * @author erosb
@@ -31,7 +34,7 @@ public class FalseSchema extends Schema {
     }
 
     @Override
-    void accept(Visitor visitor) {
+    void accept(Visitor visitor, List<String> path) {
         visitor.visitFalseSchema(this);
     }
 

--- a/core/src/main/java/org/everit/json/schema/NotSchema.java
+++ b/core/src/main/java/org/everit/json/schema/NotSchema.java
@@ -2,8 +2,11 @@ package org.everit.json.schema;
 
 import static java.util.Objects.requireNonNull;
 
+import java.util.ArrayList;
 import java.util.Objects;
+import java.util.stream.Stream;
 
+import java.util.List;
 import org.everit.json.schema.internal.JSONPrinter;
 
 /**
@@ -46,7 +49,11 @@ public class NotSchema extends Schema {
     }
 
     @Override void accept(Visitor visitor) {
-        visitor.visitNotSchema(this);
+        visitor.visitNotSchema(this, new ArrayList<>());
+    }
+
+    @Override void accept(Visitor visitor, List<String> path) {
+        visitor.visitNotSchema(this, path);
     }
 
     @Override

--- a/core/src/main/java/org/everit/json/schema/NotSchema.java
+++ b/core/src/main/java/org/everit/json/schema/NotSchema.java
@@ -4,8 +4,6 @@ import static java.util.Objects.requireNonNull;
 
 import java.util.ArrayList;
 import java.util.Objects;
-import java.util.stream.Stream;
-
 import java.util.List;
 import org.everit.json.schema.internal.JSONPrinter;
 

--- a/core/src/main/java/org/everit/json/schema/NullSchema.java
+++ b/core/src/main/java/org/everit/json/schema/NullSchema.java
@@ -3,8 +3,6 @@ package org.everit.json.schema;
 import java.util.List;
 import org.everit.json.schema.internal.JSONPrinter;
 
-import java.util.stream.Stream;
-
 /**
  * {@code Null} schema validator.
  */

--- a/core/src/main/java/org/everit/json/schema/NullSchema.java
+++ b/core/src/main/java/org/everit/json/schema/NullSchema.java
@@ -1,6 +1,9 @@
 package org.everit.json.schema;
 
+import java.util.List;
 import org.everit.json.schema.internal.JSONPrinter;
+
+import java.util.stream.Stream;
 
 /**
  * {@code Null} schema validator.
@@ -51,6 +54,10 @@ public class NullSchema extends Schema {
     }
 
     @Override void accept(Visitor visitor) {
+        visitor.visitNullSchema(this);
+    }
+
+    @Override void accept(Visitor visitor, List<String> path) {
         visitor.visitNullSchema(this);
     }
 

--- a/core/src/main/java/org/everit/json/schema/NumberSchema.java
+++ b/core/src/main/java/org/everit/json/schema/NumberSchema.java
@@ -1,7 +1,9 @@
 package org.everit.json.schema;
 
 import java.util.Objects;
+import java.util.stream.Stream;
 
+import java.util.List;
 import org.everit.json.schema.internal.JSONPrinter;
 import org.json.JSONException;
 
@@ -165,7 +167,7 @@ public class NumberSchema extends Schema {
         return exclusiveMaximumLimit;
     }
 
-    @Override void accept(Visitor visitor) {
+    @Override void accept(Visitor visitor, List<String> path) {
         visitor.visitNumberSchema(this);
     }
 

--- a/core/src/main/java/org/everit/json/schema/NumberSchema.java
+++ b/core/src/main/java/org/everit/json/schema/NumberSchema.java
@@ -1,8 +1,6 @@
 package org.everit.json.schema;
 
 import java.util.Objects;
-import java.util.stream.Stream;
-
 import java.util.List;
 import org.everit.json.schema.internal.JSONPrinter;
 import org.json.JSONException;

--- a/core/src/main/java/org/everit/json/schema/ObjectSchema.java
+++ b/core/src/main/java/org/everit/json/schema/ObjectSchema.java
@@ -263,8 +263,8 @@ public class ObjectSchema extends Schema {
         return propertyNameSchema;
     }
 
-    @Override void accept(Visitor visitor) {
-        visitor.visitObjectSchema(this);
+    @Override void accept(Visitor visitor, List<String> path) {
+        visitor.visitObjectSchema(this, path);
     }
 
     public boolean permitsAdditionalProperties() {

--- a/core/src/main/java/org/everit/json/schema/ObjectSchemaValidatingVisitor.java
+++ b/core/src/main/java/org/everit/json/schema/ObjectSchemaValidatingVisitor.java
@@ -7,7 +7,9 @@ import static org.everit.json.schema.loader.OrgJsonUtil.getNames;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Stream;
 
+import java.util.List;
 import org.everit.json.schema.regexp.Regexp;
 import org.json.JSONObject;
 
@@ -28,12 +30,12 @@ class ObjectSchemaValidatingVisitor extends Visitor {
         this.owner = requireNonNull(owner, "owner cannot be null");
     }
 
-    @Override void visitObjectSchema(ObjectSchema objectSchema) {
+    @Override void visitObjectSchema(ObjectSchema objectSchema, List<String> path) {
         if (owner.passesTypeCheck(JSONObject.class, objectSchema.requiresObject(), objectSchema.isNullable())) {
             objSubject = (JSONObject) subject;
             objectSize = objSubject.length();
             this.schema = objectSchema;
-            super.visitObjectSchema(objectSchema);
+            super.visitObjectSchema(objectSchema, path);
         }
     }
 
@@ -43,14 +45,14 @@ class ObjectSchemaValidatingVisitor extends Visitor {
         }
     }
 
-    @Override void visitPropertyNameSchema(Schema propertyNameSchema) {
+    @Override void visitPropertyNameSchema(Schema propertyNameSchema, List<String> path) {
         if (propertyNameSchema != null) {
             String[] names = getNames(objSubject);
             if (names == null || names.length == 0) {
                 return;
             }
             for (String name : names) {
-                ValidationException failure = owner.getFailureOfSchema(propertyNameSchema, name);
+                ValidationException failure = owner.getFailureOfSchema(propertyNameSchema, name, path);
                 if (failure != null) {
                     owner.failure(failure.prepend(name));
                 }
@@ -70,7 +72,7 @@ class ObjectSchemaValidatingVisitor extends Visitor {
         }
     }
 
-    @Override void visitPropertyDependencies(String ifPresent, Set<String> allMustBePresent) {
+    @Override void visitPropertyDependencies(String ifPresent, Set<String> allMustBePresent, List<String> path) {
         if (objSubject.has(ifPresent)) {
             for (String mustBePresent : allMustBePresent) {
                 if (!objSubject.has(mustBePresent)) {
@@ -92,12 +94,12 @@ class ObjectSchemaValidatingVisitor extends Visitor {
         }
     }
 
-    @Override void visitSchemaOfAdditionalProperties(Schema schemaOfAdditionalProperties) {
+    @Override void visitSchemaOfAdditionalProperties(Schema schemaOfAdditionalProperties, List<String> path) {
         if (schemaOfAdditionalProperties != null) {
             List<String> additionalPropNames = getAdditionalProperties();
             for (String propName : additionalPropNames) {
                 Object propVal = objSubject.get(propName);
-                ValidationException failure = owner.getFailureOfSchema(schemaOfAdditionalProperties, propVal);
+                ValidationException failure = owner.getFailureOfSchema(schemaOfAdditionalProperties, propVal, appendPath(path, propName));
                 if (failure != null) {
                     owner.failure(failure.prepend(propName, schema));
                 }
@@ -129,14 +131,14 @@ class ObjectSchemaValidatingVisitor extends Visitor {
         return false;
     }
 
-    @Override void visitPatternPropertySchema(Regexp propertyNamePattern, Schema schema) {
+    @Override void visitPatternPropertySchema(Regexp propertyNamePattern, Schema schema, List<String> path) {
         String[] propNames = getNames(objSubject);
         if (propNames == null || propNames.length == 0) {
             return;
         }
         for (String propName : propNames) {
             if (!propertyNamePattern.patternMatchingFailure(propName).isPresent()) {
-                ValidationException failure = owner.getFailureOfSchema(schema, objSubject.get(propName));
+                ValidationException failure = owner.getFailureOfSchema(schema, objSubject.get(propName), path);
                 if (failure != null) {
                     owner.failure(failure.prepend(propName));
                 }
@@ -144,18 +146,18 @@ class ObjectSchemaValidatingVisitor extends Visitor {
         }
     }
 
-    @Override void visitSchemaDependency(String propName, Schema schema) {
+    @Override void visitSchemaDependency(String propName, Schema schema, List<String> path) {
         if (objSubject.has(propName)) {
-            ValidationException failure = owner.getFailureOfSchema(schema, objSubject);
+            ValidationException failure = owner.getFailureOfSchema(schema, objSubject, path);
             if (failure != null) {
                 owner.failure(failure);
             }
         }
     }
 
-    @Override void visitPropertySchema(String properyName, Schema schema) {
+    @Override void visitPropertySchema(String properyName, Schema schema, List<String> path) {
         if (objSubject.has(properyName)) {
-            ValidationException failure = owner.getFailureOfSchema(schema, objSubject.get(properyName));
+            ValidationException failure = owner.getFailureOfSchema(schema, objSubject.get(properyName), path);
             if (failure != null) {
                 owner.failure(failure.prepend(properyName));
             }

--- a/core/src/main/java/org/everit/json/schema/ObjectSchemaValidatingVisitor.java
+++ b/core/src/main/java/org/everit/json/schema/ObjectSchemaValidatingVisitor.java
@@ -7,9 +7,6 @@ import static org.everit.json.schema.loader.OrgJsonUtil.getNames;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
-import java.util.stream.Stream;
-
-import java.util.List;
 import org.everit.json.schema.regexp.Regexp;
 import org.json.JSONObject;
 

--- a/core/src/main/java/org/everit/json/schema/ReferenceSchema.java
+++ b/core/src/main/java/org/everit/json/schema/ReferenceSchema.java
@@ -3,7 +3,9 @@ package org.everit.json.schema;
 import static java.util.Objects.requireNonNull;
 
 import java.util.Objects;
+import java.util.stream.Stream;
 
+import java.util.List;
 import org.everit.json.schema.internal.JSONPrinter;
 
 /**
@@ -107,8 +109,8 @@ public class ReferenceSchema extends Schema {
         return other instanceof ReferenceSchema;
     }
 
-    @Override void accept(Visitor visitor) {
-        visitor.visitReferenceSchema(this);
+    @Override void accept(Visitor visitor, List<String> path) {
+        visitor.visitReferenceSchema(this, path);
     }
 
     @Override void describePropertiesTo(JSONPrinter writer) {

--- a/core/src/main/java/org/everit/json/schema/ReferenceSchema.java
+++ b/core/src/main/java/org/everit/json/schema/ReferenceSchema.java
@@ -3,8 +3,6 @@ package org.everit.json.schema;
 import static java.util.Objects.requireNonNull;
 
 import java.util.Objects;
-import java.util.stream.Stream;
-
 import java.util.List;
 import org.everit.json.schema.internal.JSONPrinter;
 

--- a/core/src/main/java/org/everit/json/schema/Schema.java
+++ b/core/src/main/java/org/everit/json/schema/Schema.java
@@ -3,9 +3,7 @@ package org.everit.json.schema;
 import static java.util.Collections.unmodifiableMap;
 
 import java.io.StringWriter;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Objects;
+import java.util.*;
 
 import org.everit.json.schema.internal.JSONPrinter;
 import org.json.JSONWriter;
@@ -313,7 +311,11 @@ public abstract class Schema {
 
     }
 
-    abstract void accept(Visitor visitor);
+    void accept(Visitor visitor) {
+        accept(visitor, new ArrayList<>());
+    }
+
+    abstract void accept(Visitor visitor, List<String> path);
 
     @Override
     public String toString() {

--- a/core/src/main/java/org/everit/json/schema/StringSchema.java
+++ b/core/src/main/java/org/everit/json/schema/StringSchema.java
@@ -4,8 +4,6 @@ import static java.util.Objects.requireNonNull;
 import static org.everit.json.schema.FormatValidator.NONE;
 
 import java.util.Objects;
-import java.util.stream.Stream;
-
 import java.util.List;
 import org.everit.json.schema.internal.JSONPrinter;
 import org.everit.json.schema.regexp.JavaUtilRegexpFactory;

--- a/core/src/main/java/org/everit/json/schema/StringSchema.java
+++ b/core/src/main/java/org/everit/json/schema/StringSchema.java
@@ -4,7 +4,9 @@ import static java.util.Objects.requireNonNull;
 import static org.everit.json.schema.FormatValidator.NONE;
 
 import java.util.Objects;
+import java.util.stream.Stream;
 
+import java.util.List;
 import org.everit.json.schema.internal.JSONPrinter;
 import org.everit.json.schema.regexp.JavaUtilRegexpFactory;
 import org.everit.json.schema.regexp.Regexp;
@@ -128,6 +130,10 @@ public class StringSchema extends Schema {
     }
 
     @Override void accept(Visitor visitor) {
+        visitor.visitStringSchema(this);
+    }
+
+    @Override void accept(Visitor visitor, List<String> path) {
         visitor.visitStringSchema(this);
     }
 

--- a/core/src/main/java/org/everit/json/schema/ValidatingVisitor.java
+++ b/core/src/main/java/org/everit/json/schema/ValidatingVisitor.java
@@ -9,9 +9,7 @@ import static org.everit.json.schema.EnumSchema.toJavaValue;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
-import java.util.stream.Stream;
 
-import java.util.List;
 import org.everit.json.schema.event.CombinedSchemaMatchEvent;
 import org.everit.json.schema.event.CombinedSchemaMismatchEvent;
 import org.everit.json.schema.event.SchemaReferencedEvent;

--- a/core/src/main/java/org/everit/json/schema/ValidatingVisitor.java
+++ b/core/src/main/java/org/everit/json/schema/ValidatingVisitor.java
@@ -9,7 +9,9 @@ import static org.everit.json.schema.EnumSchema.toJavaValue;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.stream.Stream;
 
+import java.util.List;
 import org.everit.json.schema.event.CombinedSchemaMatchEvent;
 import org.everit.json.schema.event.CombinedSchemaMismatchEvent;
 import org.everit.json.schema.event.SchemaReferencedEvent;
@@ -44,12 +46,12 @@ class ValidatingVisitor extends Visitor {
     private final ReadWriteValidator readWriteValidator;
 
     @Override
-    void visit(Schema schema) {
+    void visit(Schema schema, List<String> path) {
         if (schema.isNullable() == Boolean.FALSE && isNull(subject)) {
             failureReporter.failure("value cannot be null", "nullable");
         }
         readWriteValidator.validate(schema, subject);
-        super.visit(schema);
+        super.visit(schema, path);
     }
 
     ValidatingVisitor(Object subject, ValidationFailureReporter failureReporter, ReadWriteValidator readWriteValidator,
@@ -69,8 +71,8 @@ class ValidatingVisitor extends Visitor {
     }
 
     @Override
-    void visitArraySchema(ArraySchema arraySchema) {
-        arraySchema.accept(new ArraySchemaValidatingVisitor(subject, this));
+    void visitArraySchema(ArraySchema arraySchema, List<String> path) {
+        arraySchema.accept(new ArraySchemaValidatingVisitor(subject, this), path);
     }
 
     @Override
@@ -115,32 +117,32 @@ class ValidatingVisitor extends Visitor {
     }
 
     @Override
-    void visitNotSchema(NotSchema notSchema) {
+    void visitNotSchema(NotSchema notSchema, List<String> path) {
         Schema mustNotMatch = notSchema.getMustNotMatch();
-        ValidationException failure = getFailureOfSchema(mustNotMatch, subject);
+        ValidationException failure = getFailureOfSchema(mustNotMatch, subject, path);
         if (failure == null) {
             failureReporter.failure("subject must not be valid against schema " + mustNotMatch, "not");
         }
     }
 
     @Override
-    void visitReferenceSchema(ReferenceSchema referenceSchema) {
+    void visitReferenceSchema(ReferenceSchema referenceSchema, List<String> path) {
         Schema referredSchema = referenceSchema.getReferredSchema();
         if (referredSchema == null) {
             throw new IllegalStateException("referredSchema must be injected before validation");
         }
-        ValidationException failure = getFailureOfSchema(referredSchema, subject);
+        ValidationException failure = getFailureOfSchema(referredSchema, subject, path);
         if (failure != null) {
             failureReporter.failure(failure);
         }
-        if (validationListener != null) {
-            validationListener.schemaReferenced(new SchemaReferencedEvent(referenceSchema, subject, referredSchema));
+        else if (validationListener != null) {
+            validationListener.schemaReferenced(new SchemaReferencedEvent(referenceSchema, subject, referredSchema, path));
         }
     }
 
     @Override
-    void visitObjectSchema(ObjectSchema objectSchema) {
-        objectSchema.accept(new ObjectSchemaValidatingVisitor(subject, this));
+    void visitObjectSchema(ObjectSchema objectSchema, List<String> path) {
+        objectSchema.accept(new ObjectSchemaValidatingVisitor(subject, this), path);
     }
 
     @Override
@@ -149,16 +151,16 @@ class ValidatingVisitor extends Visitor {
     }
 
     @Override
-    void visitCombinedSchema(CombinedSchema combinedSchema) {
+    void visitCombinedSchema(CombinedSchema combinedSchema, List<String> path) {
         Collection<Schema> subschemas = combinedSchema.getSubschemas();
         List<ValidationException> failures = new ArrayList<>(subschemas.size());
         CombinedSchema.ValidationCriterion criterion = combinedSchema.getCriterion();
         for (Schema subschema : subschemas) {
-            ValidationException exception = getFailureOfSchema(subschema, subject);
+            ValidationException exception = getFailureOfSchema(subschema, subject, path);
             if (null != exception) {
                 failures.add(exception);
             }
-            reportSchemaMatchEvent(combinedSchema, subschema, exception);
+            reportSchemaMatchEvent(combinedSchema, subschema, exception, path);
         }
         int matchingCount = subschemas.size() - failures.size();
         try {
@@ -174,22 +176,22 @@ class ValidatingVisitor extends Visitor {
     }
 
     @Override
-    void visitConditionalSchema(ConditionalSchema conditionalSchema) {
-        conditionalSchema.accept(new ConditionalSchemaValidatingVisitor(subject, this));
+    void visitConditionalSchema(ConditionalSchema conditionalSchema, List<String> path) {
+        conditionalSchema.accept(new ConditionalSchemaValidatingVisitor(subject, this), path);
     }
 
-    private void reportSchemaMatchEvent(CombinedSchema schema, Schema subschema, ValidationException failure) {
+    private void reportSchemaMatchEvent(CombinedSchema schema, Schema subschema, ValidationException failure, List<String> path) {
         if (failure == null) {
-            validationListener.combinedSchemaMatch(new CombinedSchemaMatchEvent(schema, subschema, subject));
+            validationListener.combinedSchemaMatch(new CombinedSchemaMatchEvent(schema, subschema, subject, path));
         } else {
-            validationListener.combinedSchemaMismatch(new CombinedSchemaMismatchEvent(schema, subschema, subject, failure));
+            validationListener.combinedSchemaMismatch(new CombinedSchemaMismatchEvent(schema, subschema, subject, failure, path));
         }
     }
 
-    ValidationException getFailureOfSchema(Schema schema, Object input) {
+    ValidationException getFailureOfSchema(Schema schema, Object input, List<String> path) {
         Object origSubject = this.subject;
         this.subject = input;
-        ValidationException rval = failureReporter.inContextOfSchema(schema, () -> visit(schema));
+        ValidationException rval = failureReporter.inContextOfSchema(schema, () -> visit(schema, path));
         this.subject = origSubject;
         return rval;
     }

--- a/core/src/main/java/org/everit/json/schema/Validator.java
+++ b/core/src/main/java/org/everit/json/schema/Validator.java
@@ -1,5 +1,8 @@
 package org.everit.json.schema;
 
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 import java.util.function.BiFunction;
 
 import org.everit.json.schema.event.ValidationListener;
@@ -40,6 +43,7 @@ public interface Validator {
     }
 
     void performValidation(Schema schema, Object input);
+
 }
 
 class DefaultValidator implements Validator {
@@ -63,10 +67,14 @@ class DefaultValidator implements Validator {
     }
 
     @Override public void performValidation(Schema schema, Object input) {
+        performValidation(schema, input, Collections.singletonList("#"));
+    }
+
+    public void performValidation(Schema schema, Object input, List<String> path) {
         ValidationFailureReporter failureReporter = createFailureReporter(schema);
         ReadWriteValidator readWriteValidator = ReadWriteValidator.createForContext(readWriteContext, failureReporter);
         ValidatingVisitor visitor = new ValidatingVisitor(input, failureReporter, readWriteValidator, validationListener);
-        visitor.visit(schema);
+        visitor.visit(schema, path);
         visitor.failIfErrorFound();
     }
 

--- a/core/src/main/java/org/everit/json/schema/Visitor.java
+++ b/core/src/main/java/org/everit/json/schema/Visitor.java
@@ -1,8 +1,6 @@
 package org.everit.json.schema;
 
 import java.util.*;
-import java.util.stream.Stream;
-
 import java.util.List;
 import org.everit.json.schema.regexp.Regexp;
 

--- a/core/src/main/java/org/everit/json/schema/Visitor.java
+++ b/core/src/main/java/org/everit/json/schema/Visitor.java
@@ -1,12 +1,22 @@
 package org.everit.json.schema;
 
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
+import java.util.stream.Stream;
 
+import java.util.List;
 import org.everit.json.schema.regexp.Regexp;
 
 abstract class Visitor {
+
+    List<String> appendPath(List<String> path, int index) {
+        return appendPath(path, String.format("[%d]", index));
+    }
+
+    List<String> appendPath(List<String> path, String field) {
+        List<String> newList = new ArrayList<>(path);
+        newList.add(field);
+        return newList;
+    }
 
     void visitNumberSchema(NumberSchema numberSchema) {
         visitExclusiveMinimum(numberSchema.isExclusiveMinimum());
@@ -39,24 +49,24 @@ abstract class Visitor {
     void visitMultipleOf(Number multipleOf) {
     }
 
-    void visit(Schema schema) {
-        schema.accept(this);
+    void visit(Schema schema, List<String> path) {
+        schema.accept(this, path);
     }
 
-    void visitArraySchema(ArraySchema arraySchema) {
+    void visitArraySchema(ArraySchema arraySchema, List<String> path) {
         visitMinItems(arraySchema.getMinItems());
         visitMaxItems(arraySchema.getMaxItems());
         visitUniqueItems(arraySchema.needsUniqueItems());
-        visitAllItemSchema(arraySchema.getAllItemSchema());
+        visitAllItemSchema(arraySchema.getAllItemSchema(), path);
         visitAdditionalItems(arraySchema.permitsAdditionalItems());
         List<Schema> itemSchemas = arraySchema.getItemSchemas();
         if (itemSchemas != null) {
             for (int i = 0; i < itemSchemas.size(); ++i) {
-                visitItemSchema(i, itemSchemas.get(i));
+                visitItemSchema(i, itemSchemas.get(i), appendPath(path, i));
             }
         }
-        visitSchemaOfAdditionalItems(arraySchema.getSchemaOfAdditionalItems());
-        visitContainedItemSchema(arraySchema.getContainedItemSchema());
+        visitSchemaOfAdditionalItems(arraySchema.getSchemaOfAdditionalItems(), path);
+        visitContainedItemSchema(arraySchema.getContainedItemSchema(), path);
     }
 
     void visitMinItems(Integer minItems) {
@@ -68,19 +78,19 @@ abstract class Visitor {
     void visitUniqueItems(boolean uniqueItems) {
     }
 
-    void visitAllItemSchema(Schema allItemSchema) {
+    void visitAllItemSchema(Schema allItemSchema, List<String> path) {
     }
 
     void visitAdditionalItems(boolean additionalItems) {
     }
 
-    void visitItemSchema(int index, Schema itemSchema) {
+    void visitItemSchema(int index, Schema itemSchema, List<String> path) {
     }
 
-    void visitSchemaOfAdditionalItems(Schema schemaOfAdditionalItems) {
+    void visitSchemaOfAdditionalItems(Schema schemaOfAdditionalItems, List<String> path) {
     }
 
-    void visitContainedItemSchema(Schema containedItemSchema) {
+    void visitContainedItemSchema(Schema containedItemSchema, List<String> path) {
     }
 
     void visitBooleanSchema(BooleanSchema schema) {
@@ -101,54 +111,54 @@ abstract class Visitor {
     void visitFalseSchema(FalseSchema falseSchema) {
     }
 
-    void visitNotSchema(NotSchema notSchema) {
+    void visitNotSchema(NotSchema notSchema, List<String> path) {
     }
 
-    void visitReferenceSchema(ReferenceSchema referenceSchema) {
+    void visitReferenceSchema(ReferenceSchema referenceSchema, List<String> path) {
     }
 
-    void visitObjectSchema(ObjectSchema objectSchema) {
+    void visitObjectSchema(ObjectSchema objectSchema, List<String> path) {
         for (String requiredPropName : objectSchema.getRequiredProperties()) {
             visitRequiredPropertyName(requiredPropName);
         }
-        visitPropertyNameSchema(objectSchema.getPropertyNameSchema());
+        visitPropertyNameSchema(objectSchema.getPropertyNameSchema(), path);
         visitMinProperties(objectSchema.getMinProperties());
         visitMaxProperties(objectSchema.getMaxProperties());
         for (Map.Entry<String, Set<String>> entry : objectSchema.getPropertyDependencies().entrySet()) {
-            visitPropertyDependencies(entry.getKey(), entry.getValue());
+            visitPropertyDependencies(entry.getKey(), entry.getValue(), appendPath(path, entry.getKey()));
         }
         visitAdditionalProperties(objectSchema.permitsAdditionalProperties());
-        visitSchemaOfAdditionalProperties(objectSchema.getSchemaOfAdditionalProperties());
+        visitSchemaOfAdditionalProperties(objectSchema.getSchemaOfAdditionalProperties(), path);
         for (Map.Entry<Regexp, Schema> entry : objectSchema.getRegexpPatternProperties().entrySet()) {
-            visitPatternPropertySchema(entry.getKey(), entry.getValue());
+            visitPatternPropertySchema(entry.getKey(), entry.getValue(), path);
         }
         for (Map.Entry<String, Schema> schemaDep : objectSchema.getSchemaDependencies().entrySet()) {
-            visitSchemaDependency(schemaDep.getKey(), schemaDep.getValue());
+            visitSchemaDependency(schemaDep.getKey(), schemaDep.getValue(), appendPath(path, schemaDep.getKey()));
         }
         Map<String, Schema> propertySchemas = objectSchema.getPropertySchemas();
         if (propertySchemas != null) {
             for (Map.Entry<String, Schema> entry : propertySchemas.entrySet()) {
-                visitPropertySchema(entry.getKey(), entry.getValue());
+                visitPropertySchema(entry.getKey(), entry.getValue(), appendPath(path, entry.getKey()));
             }
         }
     }
 
-    void visitPropertySchema(String properyName, Schema schema) {
+    void visitPropertySchema(String properyName, Schema schema, List<String> path) {
     }
 
-    void visitSchemaDependency(String propKey, Schema schema) {
+    void visitSchemaDependency(String propKey, Schema schema, List<String> path) {
     }
 
-    void visitPatternPropertySchema(Regexp propertyNamePattern, Schema schema) {
+    void visitPatternPropertySchema(Regexp propertyNamePattern, Schema schema, List<String> path) {
     }
 
-    void visitSchemaOfAdditionalProperties(Schema schemaOfAdditionalProperties) {
+    void visitSchemaOfAdditionalProperties(Schema schemaOfAdditionalProperties, List<String> path) {
     }
 
     void visitAdditionalProperties(boolean additionalProperties) {
     }
 
-    void visitPropertyDependencies(String ifPresent, Set<String> allMustBePresent) {
+    void visitPropertyDependencies(String ifPresent, Set<String> allMustBePresent, List<String> path) {
     }
 
     void visitMaxProperties(Integer maxProperties) {
@@ -157,7 +167,7 @@ abstract class Visitor {
     void visitMinProperties(Integer minProperties) {
     }
 
-    void visitPropertyNameSchema(Schema propertyNameSchema) {
+    void visitPropertyNameSchema(Schema propertyNameSchema, List<String> path) {
     }
 
     void visitRequiredPropertyName(String requiredPropName) {
@@ -182,21 +192,21 @@ abstract class Visitor {
     void visitMinLength(Integer minLength) {
     }
 
-    void visitCombinedSchema(CombinedSchema combinedSchema) {
+    void visitCombinedSchema(CombinedSchema combinedSchema, List<String> path) {
     }
 
-    void visitConditionalSchema(ConditionalSchema conditionalSchema) {
-        conditionalSchema.getIfSchema().ifPresent(this::visitIfSchema);
-        conditionalSchema.getThenSchema().ifPresent(this::visitThenSchema);
-        conditionalSchema.getElseSchema().ifPresent(this::visitElseSchema);
+    void visitConditionalSchema(ConditionalSchema conditionalSchema, List<String> path) {
+        conditionalSchema.getIfSchema().ifPresent(schema -> visitIfSchema(schema, path));
+        conditionalSchema.getThenSchema().ifPresent(schema -> visitThenSchema(schema, path));
+        conditionalSchema.getElseSchema().ifPresent(schema -> visitElseSchema(schema, path));
     }
 
-    void visitIfSchema(Schema ifSchema) {
+    void visitIfSchema(Schema ifSchema, List<String> path) {
     }
 
-    void visitThenSchema(Schema thenSchema) {
+    void visitThenSchema(Schema thenSchema, List<String> path) {
     }
 
-    void visitElseSchema(Schema elseSchema) {
+    void visitElseSchema(Schema elseSchema, List<String> path) {
     }
 }

--- a/core/src/main/java/org/everit/json/schema/event/CombinedSchemaMatchEvent.java
+++ b/core/src/main/java/org/everit/json/schema/event/CombinedSchemaMatchEvent.java
@@ -1,5 +1,6 @@
 package org.everit.json.schema.event;
 
+import java.util.List;
 import org.everit.json.schema.CombinedSchema;
 import org.everit.json.schema.Schema;
 import org.json.JSONObject;
@@ -7,7 +8,12 @@ import org.json.JSONObject;
 public class CombinedSchemaMatchEvent extends CombinedSchemaValidationEvent {
 
     public CombinedSchemaMatchEvent(CombinedSchema schema, Schema subSchema,
-            Object instance) {
+            Object instance, List<String> path) {
+        super(schema, subSchema, instance, path);
+    }
+
+    public CombinedSchemaMatchEvent(CombinedSchema schema, Schema subSchema,
+                                    Object instance) {
         super(schema, subSchema, instance);
     }
 

--- a/core/src/main/java/org/everit/json/schema/event/CombinedSchemaMismatchEvent.java
+++ b/core/src/main/java/org/everit/json/schema/event/CombinedSchemaMismatchEvent.java
@@ -1,8 +1,6 @@
 package org.everit.json.schema.event;
 
 import java.util.Objects;
-import java.util.stream.Stream;
-
 import java.util.List;
 import org.everit.json.schema.CombinedSchema;
 import org.everit.json.schema.Schema;

--- a/core/src/main/java/org/everit/json/schema/event/CombinedSchemaMismatchEvent.java
+++ b/core/src/main/java/org/everit/json/schema/event/CombinedSchemaMismatchEvent.java
@@ -1,7 +1,9 @@
 package org.everit.json.schema.event;
 
 import java.util.Objects;
+import java.util.stream.Stream;
 
+import java.util.List;
 import org.everit.json.schema.CombinedSchema;
 import org.everit.json.schema.Schema;
 import org.everit.json.schema.ValidationException;
@@ -11,6 +13,11 @@ import org.json.JSONTokener;
 public class CombinedSchemaMismatchEvent extends CombinedSchemaValidationEvent implements MismatchEvent {
 
     private final ValidationException failure;
+
+    public CombinedSchemaMismatchEvent(CombinedSchema schema, Schema subSchema, Object instance, ValidationException failure, List<String> path) {
+        super(schema, subSchema, instance, path);
+        this.failure = failure;
+    }
 
     public CombinedSchemaMismatchEvent(CombinedSchema schema, Schema subSchema, Object instance, ValidationException failure) {
         super(schema, subSchema, instance);

--- a/core/src/main/java/org/everit/json/schema/event/CombinedSchemaValidationEvent.java
+++ b/core/src/main/java/org/everit/json/schema/event/CombinedSchemaValidationEvent.java
@@ -1,9 +1,8 @@
 package org.everit.json.schema.event;
 
 import java.util.Objects;
-import java.util.stream.Stream;
-
 import java.util.List;
+
 import org.everit.json.schema.CombinedSchema;
 import org.everit.json.schema.Schema;
 

--- a/core/src/main/java/org/everit/json/schema/event/CombinedSchemaValidationEvent.java
+++ b/core/src/main/java/org/everit/json/schema/event/CombinedSchemaValidationEvent.java
@@ -1,13 +1,20 @@
 package org.everit.json.schema.event;
 
 import java.util.Objects;
+import java.util.stream.Stream;
 
+import java.util.List;
 import org.everit.json.schema.CombinedSchema;
 import org.everit.json.schema.Schema;
 
 public abstract class CombinedSchemaValidationEvent extends ValidationEvent<CombinedSchema> {
 
     final Schema subSchema;
+
+    public CombinedSchemaValidationEvent(CombinedSchema schema, Schema subSchema, Object instance, List<String> path) {
+        super(schema, instance, path);
+        this.subSchema = subSchema;
+    }
 
     public CombinedSchemaValidationEvent(CombinedSchema schema, Schema subSchema, Object instance) {
         super(schema, instance);

--- a/core/src/main/java/org/everit/json/schema/event/SchemaReferencedEvent.java
+++ b/core/src/main/java/org/everit/json/schema/event/SchemaReferencedEvent.java
@@ -1,7 +1,9 @@
 package org.everit.json.schema.event;
 
 import java.util.Objects;
+import java.util.stream.Stream;
 
+import java.util.List;
 import org.everit.json.schema.ReferenceSchema;
 import org.everit.json.schema.Schema;
 import org.json.JSONObject;
@@ -10,10 +12,16 @@ public class SchemaReferencedEvent extends ValidationEvent<ReferenceSchema> {
 
     private final Schema referredSchema;
 
+    public SchemaReferencedEvent(ReferenceSchema schema, Object instance, Schema referredSchema, List<String> path) {
+        super(schema, instance, path);
+        this.referredSchema = referredSchema;
+    }
+
     public SchemaReferencedEvent(ReferenceSchema schema, Object instance, Schema referredSchema) {
         super(schema, instance);
         this.referredSchema = referredSchema;
     }
+
 
     @Override
     void describeTo(JSONObject obj) {

--- a/core/src/main/java/org/everit/json/schema/event/SchemaReferencedEvent.java
+++ b/core/src/main/java/org/everit/json/schema/event/SchemaReferencedEvent.java
@@ -1,8 +1,6 @@
 package org.everit.json.schema.event;
 
 import java.util.Objects;
-import java.util.stream.Stream;
-
 import java.util.List;
 import org.everit.json.schema.ReferenceSchema;
 import org.everit.json.schema.Schema;

--- a/core/src/main/java/org/everit/json/schema/event/ValidationEvent.java
+++ b/core/src/main/java/org/everit/json/schema/event/ValidationEvent.java
@@ -2,8 +2,6 @@ package org.everit.json.schema.event;
 
 import java.util.ArrayList;
 import java.util.Objects;
-import java.util.stream.Stream;
-
 import java.util.List;
 import org.everit.json.schema.Schema;
 import org.json.JSONObject;

--- a/core/src/main/java/org/everit/json/schema/event/ValidationEvent.java
+++ b/core/src/main/java/org/everit/json/schema/event/ValidationEvent.java
@@ -1,7 +1,10 @@
 package org.everit.json.schema.event;
 
+import java.util.ArrayList;
 import java.util.Objects;
+import java.util.stream.Stream;
 
+import java.util.List;
 import org.everit.json.schema.Schema;
 import org.json.JSONObject;
 
@@ -11,10 +14,19 @@ public abstract class ValidationEvent<S extends Schema> {
 
     protected final Object instance;
 
+    protected final List<String> path;
+
     protected ValidationEvent(S schema, Object instance) {
+        this(schema, instance, new ArrayList<>());
+    }
+
+    protected ValidationEvent(S schema, Object instance, List<String> path) {
         this.schema = schema;
         this.instance = instance;
+        this.path = path;
     }
+
+    public List<String> getPath() { return path; }
 
     public S getSchema() {
         return schema;

--- a/core/src/test/java/org/everit/json/schema/ValidatingVisitorTest.java
+++ b/core/src/test/java/org/everit/json/schema/ValidatingVisitorTest.java
@@ -11,7 +11,7 @@ import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.stream.Stream;
+
 
 import java.util.List;
 import org.everit.json.schema.event.CombinedSchemaMatchEvent;

--- a/core/src/test/java/org/everit/json/schema/ValidatingVisitorTest.java
+++ b/core/src/test/java/org/everit/json/schema/ValidatingVisitorTest.java
@@ -9,7 +9,11 @@ import static org.mockito.Mockito.verifyZeroInteractions;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.stream.Stream;
 
+import java.util.List;
 import org.everit.json.schema.event.CombinedSchemaMatchEvent;
 import org.everit.json.schema.event.CombinedSchemaMismatchEvent;
 import org.everit.json.schema.event.ValidationListener;
@@ -131,12 +135,12 @@ public class ValidatingVisitorTest {
         ValidationFailureReporter reporter = new CollectingFailureReporter(combinedSchema);
         JSONObject instance = new JSONObject();
 
-        new ValidatingVisitor(instance, reporter, ReadWriteValidator.NONE, listener).visit(combinedSchema);
+        new ValidatingVisitor(instance, reporter, ReadWriteValidator.NONE, listener).visit(combinedSchema, Collections.singletonList("#"));
 
         ValidationException exc = new ValidationException(stringSchema, String.class, instance);
-        verify(listener).combinedSchemaMismatch(new CombinedSchemaMismatchEvent(combinedSchema, stringSchema, instance, exc));
-        verify(listener).combinedSchemaMatch(new CombinedSchemaMatchEvent(combinedSchema, emptySchema, instance));
-        verify(listener).combinedSchemaMatch(new CombinedSchemaMatchEvent(combinedSchema, objectSchema, instance));
+        verify(listener).combinedSchemaMismatch(new CombinedSchemaMismatchEvent(combinedSchema, stringSchema, instance, exc, new ArrayList<>()));
+        verify(listener).combinedSchemaMatch(new CombinedSchemaMatchEvent(combinedSchema, emptySchema, instance, new ArrayList<>()));
+        verify(listener).combinedSchemaMatch(new CombinedSchemaMatchEvent(combinedSchema, objectSchema, instance, new ArrayList<>()));
     }
 
 }

--- a/core/src/test/java/org/everit/json/schema/event/CombinedSchemaMatchEventTest.java
+++ b/core/src/test/java/org/everit/json/schema/event/CombinedSchemaMatchEventTest.java
@@ -11,6 +11,7 @@ public class CombinedSchemaMatchEventTest {
     public void equalsVerifier() {
         EqualsVerifier.forClass(CombinedSchemaMatchEvent.class)
                 .withNonnullFields("subSchema", "schema", "instance")
+                .withIgnoredFields("path")
                 .withRedefinedSuperclass()
                 .suppress(Warning.STRICT_INHERITANCE)
                 .verify();

--- a/core/src/test/java/org/everit/json/schema/event/CombinedSchemaMismatchEventTest.java
+++ b/core/src/test/java/org/everit/json/schema/event/CombinedSchemaMismatchEventTest.java
@@ -16,6 +16,7 @@ public class CombinedSchemaMismatchEventTest {
         ValidationException exc2 = new ValidationException(FalseSchema.INSTANCE, "message", "keyword", "#/loca/tion");
         EqualsVerifier.forClass(CombinedSchemaMismatchEvent.class)
                 .withNonnullFields("subSchema", "schema", "instance", "failure")
+                .withIgnoredFields("path")
                 .withRedefinedSuperclass()
                 .withPrefabValues(ValidationException.class, exc1, exc2)
                 .suppress(Warning.STRICT_INHERITANCE)

--- a/core/src/test/java/org/everit/json/schema/event/ConditionalSchemaMatchEventTest.java
+++ b/core/src/test/java/org/everit/json/schema/event/ConditionalSchemaMatchEventTest.java
@@ -11,6 +11,7 @@ public class ConditionalSchemaMatchEventTest {
     public void equalsVerifier() {
         EqualsVerifier.forClass(ConditionalSchemaMatchEvent.class)
                 .withNonnullFields("keyword", "schema", "instance")
+                .withIgnoredFields("path")
                 .withRedefinedSuperclass()
                 .suppress(Warning.STRICT_INHERITANCE)
                 .verify();

--- a/core/src/test/java/org/everit/json/schema/event/ConditionalSchemaMismatchEventTest.java
+++ b/core/src/test/java/org/everit/json/schema/event/ConditionalSchemaMismatchEventTest.java
@@ -16,6 +16,7 @@ public class ConditionalSchemaMismatchEventTest {
         ValidationException exc2 = new ValidationException(FalseSchema.INSTANCE, "message", "keyword", "#/loca/tion");
         EqualsVerifier.forClass(ConditionalSchemaMismatchEvent.class)
                 .withNonnullFields("keyword", "schema", "instance", "failure")
+                .withIgnoredFields("path")
                 .withRedefinedSuperclass()
                 .withPrefabValues(ValidationException.class, exc1, exc2)
                 .suppress(Warning.STRICT_INHERITANCE)

--- a/core/src/test/java/org/everit/json/schema/event/EventToStringTest.java
+++ b/core/src/test/java/org/everit/json/schema/event/EventToStringTest.java
@@ -5,6 +5,8 @@ import static org.everit.json.schema.JSONMatcher.sameJsonAs;
 import static org.everit.json.schema.event.ConditionalSchemaValidationEvent.Keyword.IF;
 import static org.junit.Assert.assertThat;
 
+import java.util.ArrayList;
+import java.util.List;
 import org.everit.json.schema.CombinedSchema;
 import org.everit.json.schema.ConditionalSchema;
 import org.everit.json.schema.FalseSchema;
@@ -16,6 +18,8 @@ import org.everit.json.schema.ValidationException;
 import org.json.JSONArray;
 import org.json.JSONObject;
 import org.junit.Test;
+
+import java.util.stream.Stream;
 
 public class EventToStringTest {
 
@@ -45,7 +49,7 @@ public class EventToStringTest {
         INSTANCE.put("hello", new JSONArray("[\"world\"]"));
     }
 
-    private static final SchemaReferencedEvent REF_EVENT = new SchemaReferencedEvent(REF_SCHEMA, INSTANCE, REFERRED_SCHEMA);
+    private static final SchemaReferencedEvent REF_EVENT = new SchemaReferencedEvent(REF_SCHEMA, INSTANCE, REFERRED_SCHEMA, new ArrayList<>());
 
     @Test
     public void schemaReferenceEventToStringTest() {
@@ -96,7 +100,7 @@ public class EventToStringTest {
     @Test
     public void combinedSchemaMatchEventToString() {
         JSONObject expected = LOADER.readObj("combined-schema-match.json");
-        CombinedSchemaMatchEvent subject = new CombinedSchemaMatchEvent(COMBINED_SCHEMA, TrueSchema.INSTANCE, INSTANCE);
+        CombinedSchemaMatchEvent subject = new CombinedSchemaMatchEvent(COMBINED_SCHEMA, TrueSchema.INSTANCE, INSTANCE, new ArrayList<>());
 
         JSONObject actual = new JSONObject(subject.toString());
 
@@ -107,7 +111,7 @@ public class EventToStringTest {
     public void combinedSchemaMismatchEventToString() {
         JSONObject expected = LOADER.readObj("combined-schema-mismatch.json");
         ValidationException exc = new ValidationException(COMBINED_SCHEMA, "message", "anyOf", "#/schema/location");
-        CombinedSchemaMismatchEvent subject = new CombinedSchemaMismatchEvent(COMBINED_SCHEMA, FalseSchema.INSTANCE, INSTANCE, exc);
+        CombinedSchemaMismatchEvent subject = new CombinedSchemaMismatchEvent(COMBINED_SCHEMA, FalseSchema.INSTANCE, INSTANCE, exc, new ArrayList<String>());
 
         JSONObject actual = new JSONObject(subject.toJSON(true, true).toString());
 

--- a/core/src/test/java/org/everit/json/schema/event/EventToStringTest.java
+++ b/core/src/test/java/org/everit/json/schema/event/EventToStringTest.java
@@ -19,7 +19,7 @@ import org.json.JSONArray;
 import org.json.JSONObject;
 import org.junit.Test;
 
-import java.util.stream.Stream;
+
 
 public class EventToStringTest {
 

--- a/core/src/test/java/org/everit/json/schema/event/SchemaReferencedEventTest.java
+++ b/core/src/test/java/org/everit/json/schema/event/SchemaReferencedEventTest.java
@@ -11,6 +11,7 @@ public class SchemaReferencedEventTest {
     public void equalsVerifier() {
         EqualsVerifier.forClass(SchemaReferencedEvent.class)
                 .withNonnullFields("referredSchema", "schema", "instance")
+                .withIgnoredFields("path")
                 .withRedefinedSuperclass()
                 .suppress(Warning.STRICT_INHERITANCE)
                 .verify();

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.everit.json</groupId>
     <artifactId>org.everit.json.schema.parent</artifactId>
-    <version>0.0.0-develop</version>
+    <version>2.0.0</version>
 
     <packaging>pom</packaging>
 

--- a/tests/android/pom.xml
+++ b/tests/android/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.everit.json</groupId>
         <artifactId>org.everit.json.schema.tests.parent</artifactId>
-        <version>0.0.0-develop</version>
+        <version>2.0.0</version>
     </parent>
 
     <artifactId>org.everit.json.schema.tests.android</artifactId>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.everit.json</groupId>
         <artifactId>org.everit.json.schema.parent</artifactId>
-        <version>0.0.0-develop</version>
+        <version>2.0.0</version>
     </parent>
 
     <artifactId>org.everit.json.schema.tests.parent</artifactId>

--- a/tests/vanilla/pom.xml
+++ b/tests/vanilla/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.everit.json</groupId>
         <artifactId>org.everit.json.schema.tests.parent</artifactId>
-        <version>0.0.0-develop</version>
+        <version>2.0.0</version>
     </parent>
 
     <artifactId>org.everit.json.schema.tests.vanilla</artifactId>


### PR DESCRIPTION
This PR aims to show a PoC of tracing how the schema is being validated, that means which subschemas are being validated regarding the location of them.

The example from https://gist.github.com/afranzi/76497177ea8bc305c355b49bc3b2f6b0 shows how we are using a complex schema to validate one SensorEvent. After validating we generate the following output:
```
// Output after validating the 1.device-sensor-wifi-event.json
SchemaReferenced("#/device", "/schemas/objects/Device/1.json")
SchemaReferenced("#/product","/schemas/objects/Product/1.json")
SchemaReferenced("#/user","/schemas/objects/User/1.json")
SchemaReferenced("#","/schemas/events/base-event/1.json")
SchemaReferenced("#","/schemas/events/base-device-event/1.json")
SchemaReferenced("#/data/scan/[0]","/schemas/objects/sensors/WifiConnection/1.json")
SchemaReferenced("#/data/scan/[1]","/schemas/objects/sensors/WifiConnection/1.json")
SchemaReferenced("#/data","/schemas/objects/sensors/SensorWifi/1.json")
```

Then we know that this event was formed by a SensorWifi data inside the `#/data` field and then inside that one the array `#/data/scan` contains two elements that validates agains the WifiConnection schema. Knowing which schema validates each item matters if the array of items can contain different types of subschemas.

I'm not really proud of this solution by passing all the paths through the `accept` and `validate` methods. So I would be open to any advice, proposal, idea, best practise to improve it.

What do you think @erosb? You can see in the [Gist](https://gist.github.com/afranzi/76497177ea8bc305c355b49bc3b2f6b0) how are we using the `ValidationListener`.

Thanks,
Regards,