### PR TITLE
error handling for classpath schema client

### DIFF
--- a/core/src/main/java/org/everit/json/schema/loader/ClassPathAwareSchemaClient.java
+++ b/core/src/main/java/org/everit/json/schema/loader/ClassPathAwareSchemaClient.java
@@ -4,7 +4,9 @@ import static java.util.Arrays.asList;
 import static java.util.Collections.unmodifiableList;
 import static java.util.Objects.requireNonNull;
 
+import java.io.IOException;
 import java.io.InputStream;
+import java.io.UncheckedIOException;
 import java.util.List;
 import java.util.Optional;
 
@@ -19,9 +21,17 @@ class ClassPathAwareSchemaClient implements SchemaClient {
     }
 
     @Override public InputStream get(String url) {
-        return handleProtocol(url)
-                .map(this::loadFromClasspath)
-                .orElseGet(() -> fallbackClient.get(url));
+        Optional<String> maybeString = handleProtocol(url);
+        if(maybeString.isPresent()) {
+            InputStream stream = this.loadFromClasspath(maybeString.get());
+            if(stream != null) {
+                return stream;
+            } else {
+                throw new UncheckedIOException(new IOException(String.format("Could not find %s", url)));
+            }
+        } else {
+            return fallbackClient.get(url);
+        }
     }
 
     private InputStream loadFromClasspath(String str) {

--- a/core/src/test/java/org/everit/json/schema/loader/ClassPathAwareSchemaClientTest.java
+++ b/core/src/test/java/org/everit/json/schema/loader/ClassPathAwareSchemaClientTest.java
@@ -7,12 +7,15 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.io.InputStream;
+import java.io.UncheckedIOException;
 
 import org.everit.json.schema.ResourceLoader;
 import org.json.JSONObject;
 import org.json.JSONTokener;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 
 import junitparams.JUnitParamsRunner;
@@ -37,6 +40,18 @@ public class ClassPathAwareSchemaClientTest {
         ClassPathAwareSchemaClient subject = new ClassPathAwareSchemaClient(fallbackClient);
         InputStream actual = subject.get("http://example.org");
         assertSame(expected, actual);
+    }
+
+    @Rule
+    public ExpectedException exception = ExpectedException.none();
+    @Test
+    public void throwsErrorOnMissingClasspathResource() {
+        exception.expect(UncheckedIOException.class);
+        exception.expectMessage("Could not find");
+
+        String url = "classpath:/bogus.json";
+        ClassPathAwareSchemaClient subject = new ClassPathAwareSchemaClient(fallbackClient);
+        subject.get(url);
     }
 
     @Test


### PR DESCRIPTION
Currently, if you reference a schema file that does not exist, you get this error message:
```
unknown protocol: classpath
```
because the `classpath` URL is being passed to the fallback client, which can't process it.

This PR improves the error message to name the classpath resource that cannot be found:
```
Caused by: java.io.IOException: Could not find classpath://com/test/predefined.json
```