### PR TITLE
Initial support for draft 2019-09

### DIFF
--- a/core/src/main/java/org/everit/json/schema/FormatValidator.java
+++ b/core/src/main/java/org/everit/json/schema/FormatValidator.java
@@ -5,6 +5,7 @@ import static java.util.Objects.requireNonNull;
 import java.util.Optional;
 
 import org.everit.json.schema.internal.DateTimeFormatValidator;
+import org.everit.json.schema.internal.DurationFormatValidator;
 import org.everit.json.schema.internal.EmailFormatValidator;
 import org.everit.json.schema.internal.HostnameFormatValidator;
 import org.everit.json.schema.internal.IPV4Validator;
@@ -54,6 +55,8 @@ public interface FormatValidator {
             return new IPV4Validator();
         case "ipv6":
             return new IPV6Validator();
+        case "duration":
+            return new DurationFormatValidator();
         default:
             throw new IllegalArgumentException("unsupported format: " + formatName);
         }

--- a/core/src/main/java/org/everit/json/schema/internal/DurationFormatValidator.java
+++ b/core/src/main/java/org/everit/json/schema/internal/DurationFormatValidator.java
@@ -1,0 +1,27 @@
+package org.everit.json.schema.internal;
+
+import org.everit.json.schema.FormatValidator;
+
+import java.time.Duration;
+import java.time.format.DateTimeParseException;
+import java.util.Optional;
+
+/**
+ * Implementation of the `duration` format value.
+ */
+public class DurationFormatValidator implements FormatValidator {
+    @Override
+    public Optional<String> validate(String subject) {
+        try {
+            Duration.parse(subject);
+            return Optional.empty();
+        } catch (DateTimeParseException ex) {
+            return Optional.of(String.format("[%s] is not a valid %s. Expected ISO-8601 duration format", subject, formatName()));
+        }
+    }
+
+    @Override
+    public String formatName() {
+        return "duration";
+    }
+}

--- a/core/src/main/java/org/everit/json/schema/loader/ExclusiveLimitHandler.java
+++ b/core/src/main/java/org/everit/json/schema/loader/ExclusiveLimitHandler.java
@@ -35,7 +35,8 @@ interface ExclusiveLimitHandler {
         switch (specVersion) {
             case DRAFT_4: return new V4ExclusiveLimitHandler();
             case DRAFT_6:
-            case DRAFT_7: return new V6ExclusiveLimitHandler();
+            case DRAFT_7:
+            case DRAFT_201909: return new V6ExclusiveLimitHandler();
             default: throw new RuntimeException("unknown spec version: " + specVersion);
         }
     }

--- a/core/src/main/java/org/everit/json/schema/loader/SchemaLoader.java
+++ b/core/src/main/java/org/everit/json/schema/loader/SchemaLoader.java
@@ -5,9 +5,7 @@ import static java.util.Collections.emptyList;
 import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.toList;
 import static org.everit.json.schema.loader.OrgJsonUtil.toMap;
-import static org.everit.json.schema.loader.SpecificationVersion.DRAFT_4;
-import static org.everit.json.schema.loader.SpecificationVersion.DRAFT_6;
-import static org.everit.json.schema.loader.SpecificationVersion.DRAFT_7;
+import static org.everit.json.schema.loader.SpecificationVersion.*;
 
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -121,6 +119,12 @@ public class SchemaLoader {
 
         public SchemaLoaderBuilder draftV7Support() {
             setSpecVersion(DRAFT_7);
+            specVersionIsExplicitlySet = true;
+            return this;
+        }
+
+        public SchemaLoaderBuilder draftV201909Support() {
+            setSpecVersion(DRAFT_201909);
             specVersionIsExplicitlySet = true;
             return this;
         }

--- a/core/src/main/java/org/everit/json/schema/loader/SpecificationVersion.java
+++ b/core/src/main/java/org/everit/json/schema/loader/SpecificationVersion.java
@@ -3,6 +3,7 @@ package org.everit.json.schema.loader;
 import org.everit.json.schema.FormatValidator;
 import org.everit.json.schema.internal.DateFormatValidator;
 import org.everit.json.schema.internal.DateTimeFormatValidator;
+import org.everit.json.schema.internal.DurationFormatValidator;
 import org.everit.json.schema.internal.EmailFormatValidator;
 import org.everit.json.schema.internal.HostnameFormatValidator;
 import org.everit.json.schema.internal.IPV4Validator;
@@ -203,7 +204,9 @@ public enum SpecificationVersion {
             new RelativeJsonPointerFormatValidator()
     );
 
-    private static final Map<String, FormatValidator> V201909_VALIDATORS = formatValidators(V7_VALIDATORS);
+    private static final Map<String, FormatValidator> V201909_VALIDATORS = formatValidators(V7_VALIDATORS,
+            new DurationFormatValidator()
+    );
 
     private static Map<String, FormatValidator> formatValidators(Map<String, FormatValidator> parent, FormatValidator... validators) {
         Map<String, FormatValidator> validatorMap = (parent == null) ? new HashMap<>() : new HashMap<>(parent);

--- a/core/src/main/java/org/everit/json/schema/loader/SpecificationVersion.java
+++ b/core/src/main/java/org/everit/json/schema/loader/SpecificationVersion.java
@@ -103,6 +103,30 @@ public enum SpecificationVersion {
         @Override Map<String, FormatValidator> defaultFormatValidators() {
             return V7_VALIDATORS;
         }
+
+    }, DRAFT_201909 {
+        @Override List<String> arrayKeywords() {
+            return V2019_ARRAY_KEYWORDS;
+        }
+
+        @Override List<String> objectKeywords() {
+            return V2019_OBJECT_KEYWORDS;
+        }
+
+        @Override public String idKeyword() {
+            return DRAFT_6.idKeyword();
+        }
+
+        @Override List<String> metaSchemaUrls() {
+            return Arrays.asList(
+                "http://json-schema.org/draft/2019-09/schema",
+                "https://json-schema.org/draft/2019-09/schema"
+            );
+        }
+
+        @Override Map<String, FormatValidator> defaultFormatValidators() {
+            return V201909_VALIDATORS;
+        }
     };
 
     static SpecificationVersion getByMetaSchemaUrl(String metaSchemaUrl) {
@@ -117,6 +141,18 @@ public enum SpecificationVersion {
                 .filter(v -> v.metaSchemaUrls().stream().anyMatch(metaSchemaUrl::startsWith))
                 .findFirst();
     }
+
+    private static final List<String> V2019_OBJECT_KEYWORDS = keywords("properties", "required",
+            "minProperties",
+            "maxProperties",
+            "dependencies",
+            "patternProperties",
+            "additionalProperties",
+            "propertyNames",
+            "dependentSchemas");
+
+    private static final List<String> V2019_ARRAY_KEYWORDS = keywords("items", "additionalItems", "minItems",
+            "maxItems", "uniqueItems", "contains", "unevaluatedItems");
 
     private static final List<String> V6_OBJECT_KEYWORDS = keywords("properties", "required",
             "minProperties",
@@ -166,6 +202,8 @@ public enum SpecificationVersion {
             new RegexFormatValidator(),
             new RelativeJsonPointerFormatValidator()
     );
+
+    private static final Map<String, FormatValidator> V201909_VALIDATORS = formatValidators(V7_VALIDATORS);
 
     private static Map<String, FormatValidator> formatValidators(Map<String, FormatValidator> parent, FormatValidator... validators) {
         Map<String, FormatValidator> validatorMap = (parent == null) ? new HashMap<>() : new HashMap<>(parent);

--- a/core/src/test/java/org/everit/json/schema/FormatValidatorTest.java
+++ b/core/src/test/java/org/everit/json/schema/FormatValidatorTest.java
@@ -34,7 +34,8 @@ public class FormatValidatorTest {
                 new Object[] { "hostname" },
                 new Object[] { "ipv6" },
                 new Object[] { "ipv4" },
-                new Object[] { "uri" }
+                new Object[] { "uri" },
+                new Object[] { "duration" }
         );
     }
 

--- a/core/src/test/java/org/everit/json/schema/internal/DefaultFormatValidatorTest.java
+++ b/core/src/test/java/org/everit/json/schema/internal/DefaultFormatValidatorTest.java
@@ -348,4 +348,11 @@ public class DefaultFormatValidatorTest {
         assertFailure("^(abc]", new RegexFormatValidator(), "[^(abc]] is not a valid regular expression");
     }
 
+    @Test
+    public void durationSuccess() {
+        assertSuccess("P1D", new DurationFormatValidator());
+        assertSuccess("PT1H", new DurationFormatValidator());
+        assertSuccess("PT20.345S", new DurationFormatValidator());
+        assertSuccess("P2DT3H4M", new DurationFormatValidator());
+    }
 }

--- a/core/src/test/java/org/everit/json/schema/loader/SchemaLoaderTest.java
+++ b/core/src/test/java/org/everit/json/schema/loader/SchemaLoaderTest.java
@@ -8,7 +8,7 @@ import static org.everit.json.schema.TestSupport.asStream;
 import static org.everit.json.schema.TestSupport.loadAsV6;
 import static org.everit.json.schema.TestSupport.loadAsV7;
 import static org.everit.json.schema.TestSupport.v6Loader;
-import static org.everit.json.schema.loader.SpecificationVersion.DRAFT_6;
+import static org.everit.json.schema.loader.SpecificationVersion.*;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -823,6 +823,14 @@ public class SchemaLoaderTest {
             .schemaJson(new JSONObject("{}"))
             .build().load().build();
         assertEquals(new SchemaLocation(new URI("http://example.org"), emptyList()), actual.getLocation());
+    }
+
+    @Test
+    public void canRecognizeDraft201909() {
+        SchemaLoaderBuilder builder = SchemaLoader.builder();
+        SchemaLoader loader = builder.schemaJson(get("explicitSchemaVersionFor201909")).build();
+        assertEquals(DRAFT_201909.defaultFormatValidators(), builder.formatValidators);
+        assertEquals(DRAFT_201909, loader.specVersion());
     }
 
 }

--- a/core/src/test/resources/org/everit/jsonvalidator/testschemas.json
+++ b/core/src/test/resources/org/everit/jsonvalidator/testschemas.json
@@ -730,5 +730,9 @@
         }
       }
     }
+  },
+  "explicitSchemaVersionFor201909": {
+    "$schema": "http://json-schema.org/draft/2019-09/schema",
+    "type": "object"
   }
 }

--- a/tests/vanilla/src/main/java/org/everit/json/schema/V201909TestSuiteTest.java
+++ b/tests/vanilla/src/main/java/org/everit/json/schema/V201909TestSuiteTest.java
@@ -1,0 +1,49 @@
+package org.everit.json.schema;
+
+import org.everit.json.schema.loader.SchemaLoader;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.List;
+
+@RunWith(Parameterized.class)
+public class V201909TestSuiteTest {
+
+
+        private static JettyWrapper server;
+
+        @Parameterized.Parameters(name = "{1}")
+        public static List<Object[]> params() {
+            return TestCase.loadAsParamsFromPackage("org.everit.json.schema.draft201909");
+        }
+
+        @BeforeClass
+        public static void startJetty() throws Exception {
+            (server = new JettyWrapper("/org/everit/json/schema/remotes")).start();
+        }
+
+        @AfterClass
+        public static void stopJetty() throws Exception {
+            server.stop();
+        }
+
+        private TestCase tc;
+
+        public V201909TestSuiteTest(TestCase testcase, String descr) {
+            this.tc = testcase;
+            tc.loadSchema(SchemaLoader.builder().draftV201909Support());
+        }
+
+        @Test
+        public void testInCollectingMode() {
+            tc.runTestInCollectingMode();
+        }
+
+        @Test
+        public void testInEarlyFailingMode() {
+            tc.runTestInEarlyFailureMode();
+        }
+    }

--- a/tests/vanilla/src/main/resources/org/everit/json/schema/draft201909/duration.json
+++ b/tests/vanilla/src/main/resources/org/everit/json/schema/draft201909/duration.json
@@ -1,0 +1,18 @@
+[
+  {
+    "description": "validation of duration strings",
+    "schema": {"format": "duration"},
+    "tests": [
+      {
+        "description": "a valid duration string",
+        "data": "P4DT12H30M5S",
+        "valid": true
+      },
+      {
+        "description": "an invalid duration string",
+        "data": "PT1D",
+        "valid": false
+      }
+    ]
+  }
+]


### PR DESCRIPTION
Hi,
We use json-schema in our internal project, and we want to use duration support in draft 2019-09, I'm aware the talk in this thread https://github.com/everit-org/json-schema/issues/329, it's indeed a big change. 
After a rough reading of the draft 2019-09, I made some codes hoping it could provide any help to make the work happen. In this pr:
- managed to load schemas defined using 2019-09 draft schema, the implementation should be backward compatible with draft 7 for now.
- added integration test for draft 2019-09, and it'll allow us import more tests from https://github.com/json-schema-org/JSON-Schema-Test-Suite
- added duration format support

Feel free to merge it or close it, I can add more codes if you need, like output schema support, other things specified in the change log.