### PR TITLE
#302: do not use ReferenceSchema#referredSchema for equals+hashCode

### DIFF
--- a/core/src/main/java/org/everit/json/schema/ReferenceSchema.java
+++ b/core/src/main/java/org/everit/json/schema/ReferenceSchema.java
@@ -145,7 +145,6 @@ public class ReferenceSchema extends Schema {
             return that.canEqual(this) &&
                     Objects.equals(refValue, that.refValue) &&
                     Objects.equals(unprocessedProperties, that.unprocessedProperties) &&
-                    Objects.equals(referredSchema, that.referredSchema) &&
                     Objects.equals(title, that.title) &&
                     Objects.equals(description, that.description) &&
                     super.equals(that);
@@ -156,7 +155,7 @@ public class ReferenceSchema extends Schema {
 
     @Override
     public int hashCode() {
-        return Objects.hash(super.hashCode(), referredSchema, refValue, unprocessedProperties, title, description);
+        return Objects.hash(super.hashCode(), refValue, unprocessedProperties, title, description);
     }
 
     @Override

--- a/core/src/test/java/org/everit/json/schema/HashCodeRecursionTest.java
+++ b/core/src/test/java/org/everit/json/schema/HashCodeRecursionTest.java
@@ -1,0 +1,29 @@
+package org.everit.json.schema;
+
+import org.everit.json.schema.loader.SchemaLoader;
+import org.json.JSONObject;
+import org.json.JSONTokener;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+public class HashCodeRecursionTest
+{
+    @Test
+    public void hashCode_should_not_produce_stackoverflow_on_cyclic_schema() throws IOException
+    {
+        JSONObject schemaJson;
+        try (InputStream inStream = getClass().getResourceAsStream("/org/everit/jsonvalidator/cyclic.json")) {
+            schemaJson = new JSONObject(new JSONTokener(inStream));
+        }
+
+        Schema schema = new SchemaLoader.SchemaLoaderBuilder()
+            .schemaJson(schemaJson)
+            .build()
+            .load()
+            .build();
+
+        schema.hashCode();
+    }
+}

--- a/core/src/test/java/org/everit/json/schema/ReferenceSchemaTest.java
+++ b/core/src/test/java/org/everit/json/schema/ReferenceSchemaTest.java
@@ -76,7 +76,7 @@ public class ReferenceSchemaTest {
     public void equalsVerifier() {
         EqualsVerifier.forClass(ReferenceSchema.class)
                 .withRedefinedSuperclass()
-                .withIgnoredFields("schemaLocation", "location")
+                .withIgnoredFields("schemaLocation", "location", "referredSchema")
                 //there are specifically some non final fields for loading of recursive schemas
                 .suppress(Warning.NONFINAL_FIELDS)
                 .suppress(Warning.STRICT_INHERITANCE)

--- a/core/src/test/resources/org/everit/jsonvalidator/cyclic.json
+++ b/core/src/test/resources/org/everit/jsonvalidator/cyclic.json
@@ -1,0 +1,28 @@
+{
+    "$schema": "http://json-schema.org/draft-06/schema#",
+    "type": "object",
+    "title": "Foo Schema",
+    "allOf": [
+        {
+            "$ref": "#/definitions/Foo"
+        }
+    ],
+    "definitions": {
+        "Bar": {
+            "type": "object",
+            "properties": {
+                "foo": {
+                    "$ref": "#/definitions/Foo"
+                }
+            }
+        },
+        "Foo": {
+            "type": "object",
+            "properties": {
+                "bar": {
+                    "$ref": "#/definitions/Bar"
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
This solves Issue #302. Not including the referred schema feels right to me since it depends on the schemaLoader. I have no idea whether people rely on referredSchema being in equals+hashCode, though.