### PR TITLE
Add support for non-dialect specific schema URLs

### DIFF
--- a/core/src/main/java/org/everit/json/schema/loader/SpecificationVersion.java
+++ b/core/src/main/java/org/everit/json/schema/loader/SpecificationVersion.java
@@ -48,7 +48,9 @@ public enum SpecificationVersion {
         @Override List<String> metaSchemaUrls() {
             return Arrays.asList(
                 "http://json-schema.org/draft-04/schema",
-                "https://json-schema.org/draft-04/schema"
+                "https://json-schema.org/draft-04/schema",
+                "http://json-schema.org/schema",
+                "https://json-schema.org/schema"
             );
         }
 


### PR DESCRIPTION
This is a fix for issue #431 