### PR TITLE
Upgrade Guava dependency due CVE 2020-8908 and other library upgrades

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -230,13 +230,13 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
-            <version>5.7.0</version>
+            <version>5.8.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>commons-validator</groupId>
             <artifactId>commons-validator</artifactId>
-            <version>1.6</version>
+            <version>1.7</version>
             <exclusions>
                 <exclusion>
                     <artifactId>commons-beanutils</artifactId>
@@ -247,7 +247,7 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>1.10.19</version>
+            <version>4.2.0</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>
@@ -259,7 +259,7 @@
         <dependency>
             <groupId>nl.jqno.equalsverifier</groupId>
             <artifactId>equalsverifier</artifactId>
-            <version>3.0.3</version>
+            <version>3.8.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -270,12 +270,12 @@
         <dependency>
             <groupId>com.google.re2j</groupId>
             <artifactId>re2j</artifactId>
-            <version>1.3</version>
+            <version>1.6</version>
         </dependency>
         <dependency>
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest-core</artifactId>
-            <version>1.3</version>
+            <version>2.2</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -224,7 +224,7 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>29.0-jre</version>
+            <version>31.0.1-jre</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/core/src/main/java/org/everit/json/schema/loader/SpecificationVersion.java
+++ b/core/src/main/java/org/everit/json/schema/loader/SpecificationVersion.java
@@ -48,7 +48,9 @@ public enum SpecificationVersion {
         @Override List<String> metaSchemaUrls() {
             return Arrays.asList(
                 "http://json-schema.org/draft-04/schema",
-                "https://json-schema.org/draft-04/schema"
+                "https://json-schema.org/draft-04/schema",
+                "http://json-schema.org/schema",
+                "https://json-schema.org/schema"
             );
         }
 

--- a/core/src/test/java/org/everit/json/schema/ValidatingVisitorTest.java
+++ b/core/src/test/java/org/everit/json/schema/ValidatingVisitorTest.java
@@ -3,7 +3,7 @@ package org.everit.json.schema;
 import static org.everit.json.schema.PrimitiveValidationStrategy.LENIENT;
 import static org.everit.json.schema.PrimitiveValidationStrategy.STRICT;
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Matchers.any;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;

--- a/core/src/test/java/org/everit/json/schema/loader/JsonObjectTest.java
+++ b/core/src/test/java/org/everit/json/schema/loader/JsonObjectTest.java
@@ -4,7 +4,7 @@ import static org.everit.json.schema.loader.JsonValueTest.asV6Value;
 import static org.everit.json.schema.loader.JsonValueTest.withLs;
 import static org.everit.json.schema.loader.OrgJsonUtil.toMap;
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Matchers.any;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;

--- a/core/src/test/java/org/everit/json/schema/loader/JsonValueTest.java
+++ b/core/src/test/java/org/everit/json/schema/loader/JsonValueTest.java
@@ -1,27 +1,5 @@
 package org.everit.json.schema.loader;
 
-import static java.util.Arrays.asList;
-import static java.util.Collections.emptyList;
-import static java.util.Collections.emptyMap;
-import static org.everit.json.schema.loader.JsonObjectTest.mockConsumer;
-import static org.hamcrest.CoreMatchers.instanceOf;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.verify;
-
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.function.Consumer;
-import java.util.function.Function;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
-
 import org.everit.json.schema.SchemaException;
 import org.everit.json.schema.SchemaLocation;
 import org.everit.json.schema.loader.internal.DefaultSchemaClient;
@@ -31,6 +9,24 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
+import static java.util.Collections.emptyMap;
+import static org.everit.json.schema.loader.JsonObjectTest.mockConsumer;
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
 
 /**
  * @author erosb

--- a/core/src/test/java/org/everit/json/schema/loader/JsonValueTest.java
+++ b/core/src/test/java/org/everit/json/schema/loader/JsonValueTest.java
@@ -1,22 +1,5 @@
 package org.everit.json.schema.loader;
 
-import org.everit.json.schema.SchemaException;
-import org.everit.json.schema.SchemaLocation;
-import org.everit.json.schema.loader.internal.DefaultSchemaClient;
-import org.json.JSONArray;
-import org.json.JSONObject;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.MethodSource;
-
-import java.util.HashMap;
-import java.util.List;
-import java.util.function.Consumer;
-import java.util.function.Function;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
-
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.emptyMap;
@@ -26,7 +9,26 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.everit.json.schema.SchemaException;
+import org.everit.json.schema.SchemaLocation;
+import org.everit.json.schema.loader.internal.DefaultSchemaClient;
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 /**
  * @author erosb

--- a/core/src/test/java/org/everit/json/schema/loader/ProjectedJsonObjectTest.java
+++ b/core/src/test/java/org/everit/json/schema/loader/ProjectedJsonObjectTest.java
@@ -4,7 +4,7 @@ import static java.util.Arrays.asList;
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.singleton;
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Matchers.any;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;

--- a/core/src/test/java/org/everit/json/schema/loader/internal/TypeBasedMultiplexerTest.java
+++ b/core/src/test/java/org/everit/json/schema/loader/internal/TypeBasedMultiplexerTest.java
@@ -27,6 +27,7 @@ import org.mockito.Mockito;
 
 import java.net.URI;
 import java.net.URISyntaxException;
+import static org.mockito.hamcrest.MockitoHamcrest.argThat;
 
 public class TypeBasedMultiplexerTest {
 
@@ -54,7 +55,7 @@ public class TypeBasedMultiplexerTest {
         subject.ifObject().then(o -> {
         }).requireAny();
         Mockito.verify(mockListener).resolutionScopeChanged(
-                Mockito.argThat(uriAsString("http://origchangedId")));
+                argThat(uriAsString("http://origchangedId")));
         Mockito.verify(mockListener).resolutionScopeChanged(uri("http://orig"));
     }
 
@@ -66,7 +67,7 @@ public class TypeBasedMultiplexerTest {
         subject.addResolutionScopeChangeListener(mockListener);
         subject.ifObject().then(o -> {
         }).requireAny();
-        Mockito.verify(mockListener).resolutionScopeChanged(Mockito.argThat(uriAsString(newScope)));
+        Mockito.verify(mockListener).resolutionScopeChanged(argThat(uriAsString(newScope)));
         Mockito.verify(mockListener).resolutionScopeChanged(uri(origScope));
     }
 


### PR DESCRIPTION
Hi @erosb,

please be patient with me as this is my first contribution to an OpenSource project. I checked the [contributing guidelines](https://github.com/everit-org/json-schema/blob/master/CONTRIBUTING.md), but I raise a PR not actually for a bug report - I just would like to upgrade the dependencies. 

The OWASP Dependency check reported issues that I tracked down being being the [Guava Library](https://mvnrepository.com/artifact/com.google.guava/guava) in Version [29.0-jre](https://mvnrepository.com/artifact/com.google.guava/guava/29.0-jre) being vulnerble to [CVE-2020-8908](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-8908), which is referenced in [json-schema/core/pom.xml](https://github.com/GittiMcHub/json-schema/blob/13716721902f5db86c0d2603c26a21fe927c4ded/core/pom.xml#L227)
```
        <dependency>
            <groupId>com.google.guava</groupId>
            <artifactId>guava</artifactId>
            <version>29.0-jre</version>
            <scope>test</scope>
        </dependency>
```

I then saw additional library upgrades available and bumped the version to the latest - due breaking changes in the Mockito library, I had to do a minor fix in the tests as well.

Using 
```
mvn clean install
```
The changes seem to work. 

```
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary for org.everit.json.schema.parent 0.0.0-develop:
[INFO] 
[INFO] everit-org/json-schema ............................. SUCCESS [ 13.401 s]
[INFO] org.everit.json.schema.parent ...................... SUCCESS [  0.037 s]
[INFO] org.everit.json.schema.tests.parent ................ SUCCESS [  0.004 s]
[INFO] org.everit.json.schema.tests.vanilla ............... SUCCESS [  3.897 s]
[INFO] org.everit.json.schema.tests.android ............... SUCCESS [  3.465 s]
[INFO] org.everit.json.schema.tests.slim .................. SUCCESS [  3.445 s]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  24.943 s
[INFO] Finished at: 2022-01-20T08:46:02-08:00
[INFO] ------------------------------------------------------------------------
```
