### PR TITLE
schema builder fluency

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -167,6 +167,12 @@
                                 <sourceCompatible>true</sourceCompatible>
                             </overrideCompatibilityChangeParameter>
                             <overrideCompatibilityChangeParameter>
+                                <compatibilityChange>METHOD_REMOVED</compatibilityChange>
+                                <binaryCompatible>true</binaryCompatible>
+                                <sourceCompatible>true</sourceCompatible>
+                                <semanticVersionLevel>MAJOR</semanticVersionLevel>
+                            </overrideCompatibilityChangeParameter>
+                            <overrideCompatibilityChangeParameter>
                                 <compatibilityChange>METHOD_RETURN_TYPE_CHANGED</compatibilityChange>
                                 <binaryCompatible>true</binaryCompatible>
                                 <sourceCompatible>true</sourceCompatible>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -166,6 +166,24 @@
                                 <binaryCompatible>true</binaryCompatible>
                                 <sourceCompatible>true</sourceCompatible>
                             </overrideCompatibilityChangeParameter>
+                            <overrideCompatibilityChangeParameter>
+                                <compatibilityChange>METHOD_RETURN_TYPE_CHANGED</compatibilityChange>
+                                <binaryCompatible>true</binaryCompatible>
+                                <sourceCompatible>true</sourceCompatible>
+                                <semanticVersionLevel>MAJOR</semanticVersionLevel>
+                            </overrideCompatibilityChangeParameter>
+                            <overrideCompatibilityChangeParameter>
+                                <compatibilityChange>CONSTRUCTOR_REMOVED</compatibilityChange>
+                                <binaryCompatible>true</binaryCompatible>
+                                <sourceCompatible>true</sourceCompatible>
+                                <semanticVersionLevel>MAJOR</semanticVersionLevel>
+                            </overrideCompatibilityChangeParameter>
+                            <overrideCompatibilityChangeParameter>
+                                <compatibilityChange>METHOD_ABSTRACT_ADDED_TO_CLASS</compatibilityChange>
+                                <binaryCompatible>true</binaryCompatible>
+                                <sourceCompatible>true</sourceCompatible>
+                                <semanticVersionLevel>MAJOR</semanticVersionLevel>
+                            </overrideCompatibilityChangeParameter>
                         </overrideCompatibilityChangeParameters>
                     </parameter>
                 </configuration>

--- a/core/src/main/java/org/everit/json/schema/ArraySchema.java
+++ b/core/src/main/java/org/everit/json/schema/ArraySchema.java
@@ -19,7 +19,7 @@ public class ArraySchema
      * Builder class for {@link ArraySchema}.
      */
     public static class Builder
-            extends Schema.Builder<ArraySchema> {
+            extends Schema.Builder<ArraySchema, Builder> {
 
         private boolean requiresArray = true;
 
@@ -38,6 +38,12 @@ public class ArraySchema
         private Schema schemaOfAdditionalItems;
 
         private Schema containedItemSchema;
+
+        @Override
+        protected Builder getBuilder()
+        {
+            return this;
+        }
 
         /**
          * Adds an item schema for tuple validation. The array items of the subject under validation

--- a/core/src/main/java/org/everit/json/schema/BooleanSchema.java
+++ b/core/src/main/java/org/everit/json/schema/BooleanSchema.java
@@ -12,7 +12,13 @@ public class BooleanSchema extends Schema {
     /**
      * Builder class for {@link BooleanSchema}.
      */
-    public static class Builder extends Schema.Builder<BooleanSchema> {
+    public static class Builder extends Schema.Builder<BooleanSchema, Builder> {
+
+        @Override
+        protected Builder getBuilder()
+        {
+            return this;
+        }
 
         @Override
         public BooleanSchema build() {

--- a/core/src/main/java/org/everit/json/schema/CombinedSchema.java
+++ b/core/src/main/java/org/everit/json/schema/CombinedSchema.java
@@ -17,13 +17,19 @@ public class CombinedSchema extends Schema {
     /**
      * Builder class for {@link CombinedSchema}.
      */
-    public static class Builder extends Schema.Builder<CombinedSchema> {
+    public static class Builder extends Schema.Builder<CombinedSchema, Builder> {
 
         private ValidationCriterion criterion;
 
         private Collection<Schema> subschemas = new ArrayList<>();
 
         private boolean synthetic;
+
+        @Override
+        protected Builder getBuilder()
+        {
+            return this;
+        }
 
         @Override
         public CombinedSchema build() {

--- a/core/src/main/java/org/everit/json/schema/ConditionalSchema.java
+++ b/core/src/main/java/org/everit/json/schema/ConditionalSchema.java
@@ -10,10 +10,16 @@ public class ConditionalSchema extends Schema {
     /**
      * Builder class for {@link ConditionalSchema}.
      */
-    public static class Builder extends Schema.Builder<ConditionalSchema> {
+    public static class Builder extends Schema.Builder<ConditionalSchema, Builder> {
         private Schema ifSchema;
         private Schema thenSchema;
         private Schema elseSchema;
+
+        @Override
+        protected Builder getBuilder()
+        {
+            return this;
+        }
 
         public Builder ifSchema(final Schema ifSchema) {
             this.ifSchema = ifSchema;

--- a/core/src/main/java/org/everit/json/schema/ConstSchema.java
+++ b/core/src/main/java/org/everit/json/schema/ConstSchema.java
@@ -4,12 +4,18 @@ import static org.everit.json.schema.EnumSchema.toJavaValue;
 
 public class ConstSchema extends Schema {
 
-    public static class ConstSchemaBuilder extends Schema.Builder<ConstSchema> {
+    public static class ConstSchemaBuilder extends Schema.Builder<ConstSchema, ConstSchemaBuilder> {
 
         private Object permittedValue;
 
         public ConstSchemaBuilder permittedValue(Object permittedValue) {
             this.permittedValue = permittedValue;
+            return this;
+        }
+
+        @Override
+        protected ConstSchemaBuilder getBuilder()
+        {
             return this;
         }
 

--- a/core/src/main/java/org/everit/json/schema/ConstSchema.java
+++ b/core/src/main/java/org/everit/json/schema/ConstSchema.java
@@ -4,17 +4,24 @@ import static org.everit.json.schema.EnumSchema.toJavaValue;
 
 public class ConstSchema extends Schema {
 
-    public static class ConstSchemaBuilder extends Schema.Builder<ConstSchema, ConstSchemaBuilder> {
+    /**
+     * @deprecated This class has been renamed to "Builder".
+     */
+    @Deprecated
+    public static class ConstSchemaBuilder extends Builder {
+    }
+
+    public static class Builder extends Schema.Builder<ConstSchema, Builder> {
 
         private Object permittedValue;
 
-        public ConstSchemaBuilder permittedValue(Object permittedValue) {
+        public Builder permittedValue(Object permittedValue) {
             this.permittedValue = permittedValue;
             return this;
         }
 
         @Override
-        protected ConstSchemaBuilder getBuilder()
+        protected Builder getBuilder()
         {
             return this;
         }
@@ -24,13 +31,13 @@ public class ConstSchema extends Schema {
         }
     }
 
-    public static ConstSchemaBuilder builder() {
-        return new ConstSchemaBuilder();
+    public static Builder builder() {
+        return new Builder();
     }
 
     private final Object permittedValue;
 
-    protected ConstSchema(ConstSchemaBuilder builder) {
+    protected ConstSchema(Builder builder) {
         super(builder);
         this.permittedValue = toJavaValue(builder.permittedValue);
     }

--- a/core/src/main/java/org/everit/json/schema/EmptySchema.java
+++ b/core/src/main/java/org/everit/json/schema/EmptySchema.java
@@ -10,7 +10,13 @@ public class EmptySchema extends Schema {
     /**
      * Builder class for {@link EmptySchema}.
      */
-    public static class Builder extends Schema.Builder<EmptySchema> {
+    public static class Builder extends Schema.Builder<EmptySchema, Builder> {
+
+        @Override
+        protected Builder getBuilder()
+        {
+            return this;
+        }
 
         @Override
         public EmptySchema build() {

--- a/core/src/main/java/org/everit/json/schema/EnumSchema.java
+++ b/core/src/main/java/org/everit/json/schema/EnumSchema.java
@@ -38,7 +38,13 @@ public class EnumSchema extends Schema {
     /**
      * Builder class for {@link EnumSchema}.
      */
-    public static class Builder extends Schema.Builder<EnumSchema> {
+    public static class Builder extends Schema.Builder<EnumSchema, Builder> {
+
+        @Override
+        protected Builder getBuilder()
+        {
+            return this;
+        }
 
         private List<Object> possibleValues = new ArrayList<>();
 

--- a/core/src/main/java/org/everit/json/schema/FalseSchema.java
+++ b/core/src/main/java/org/everit/json/schema/FalseSchema.java
@@ -5,7 +5,13 @@ package org.everit.json.schema;
  */
 public class FalseSchema extends Schema {
 
-    public static class Builder extends Schema.Builder<FalseSchema> {
+    public static class Builder extends Schema.Builder<FalseSchema, Builder> {
+
+        @Override
+        protected Builder getBuilder()
+        {
+            return this;
+        }
 
         @Override public FalseSchema build() {
             return new FalseSchema(this);

--- a/core/src/main/java/org/everit/json/schema/NotSchema.java
+++ b/core/src/main/java/org/everit/json/schema/NotSchema.java
@@ -12,7 +12,13 @@ public class NotSchema extends Schema {
     /**
      * Builder class for {@link NotSchema}.
      */
-    public static class Builder extends Schema.Builder<NotSchema> {
+    public static class Builder extends Schema.Builder<NotSchema, Builder> {
+
+        @Override
+        protected Builder getBuilder()
+        {
+            return this;
+        }
 
         private Schema mustNotMatch;
 

--- a/core/src/main/java/org/everit/json/schema/NullSchema.java
+++ b/core/src/main/java/org/everit/json/schema/NullSchema.java
@@ -8,7 +8,13 @@ public class NullSchema extends Schema {
     /**
      * Builder class for {@link NullSchema}.
      */
-    public static class Builder extends Schema.Builder<NullSchema> {
+    public static class Builder extends Schema.Builder<NullSchema, Builder> {
+
+        @Override
+        protected Builder getBuilder()
+        {
+            return this;
+        }
 
         @Override
         public NullSchema build() {

--- a/core/src/main/java/org/everit/json/schema/NumberSchema.java
+++ b/core/src/main/java/org/everit/json/schema/NumberSchema.java
@@ -10,7 +10,7 @@ public class NumberSchema extends Schema {
     /**
      * Builder class for {@link NumberSchema}.
      */
-    public static class Builder extends Schema.Builder<NumberSchema> {
+    public static class Builder extends Schema.Builder<NumberSchema, Builder> {
 
         private Number minimum;
 
@@ -29,6 +29,12 @@ public class NumberSchema extends Schema {
         private boolean requiresNumber = true;
 
         private boolean requiresInteger = false;
+
+        @Override
+        protected Builder getBuilder()
+        {
+            return this;
+        }
 
         @Override
         public NumberSchema build() {

--- a/core/src/main/java/org/everit/json/schema/ObjectSchema.java
+++ b/core/src/main/java/org/everit/json/schema/ObjectSchema.java
@@ -27,11 +27,11 @@ public class ObjectSchema extends Schema {
     /**
      * Builder class for {@link ObjectSchema}.
      */
-    public static class Builder extends Schema.Builder<ObjectSchema> {
+    public static class Builder extends Schema.Builder<ObjectSchema, Builder> {
 
         private static final RegexpFactory DEFAULT_REGEXP_FACTORY = new JavaUtilRegexpFactory();
 
-        private static final Regexp toRegexp(String pattern) {
+        private static Regexp toRegexp(String pattern) {
             return DEFAULT_REGEXP_FACTORY.createHandler(pattern);
         }
 
@@ -58,6 +58,12 @@ public class ObjectSchema extends Schema {
         private Schema propertyNameSchema;
 
         public boolean oneOrMoreDefaultProperty = false;
+
+        @Override
+        protected Builder getBuilder()
+        {
+            return this;
+        }
 
         public Builder additionalProperties(boolean additionalProperties) {
             this.additionalProperties = additionalProperties;
@@ -159,7 +165,6 @@ public class ObjectSchema extends Schema {
             this.propertyNameSchema = propertyNameSchema;
             return this;
         }
-
     }
 
     public static Builder builder() {

--- a/core/src/main/java/org/everit/json/schema/ReferenceSchema.java
+++ b/core/src/main/java/org/everit/json/schema/ReferenceSchema.java
@@ -16,7 +16,7 @@ public class ReferenceSchema extends Schema {
     /**
      * Builder class for {@link ReferenceSchema}.
      */
-    public static class Builder extends Schema.Builder<ReferenceSchema> {
+    public static class Builder extends Schema.Builder<ReferenceSchema, Builder> {
 
         private ReferenceSchema retval;
 
@@ -24,6 +24,12 @@ public class ReferenceSchema extends Schema {
          * The value of {@code "$ref"}
          */
         private String refValue = "";
+
+        @Override
+        protected Builder getBuilder()
+        {
+            return this;
+        }
 
         /**
          * This method caches its result, so multiple invocations will return referentially the same

--- a/core/src/main/java/org/everit/json/schema/Schema.java
+++ b/core/src/main/java/org/everit/json/schema/Schema.java
@@ -23,7 +23,7 @@ public abstract class Schema {
      * @param <S>
      *         the type of the schema being built by the builder subclass.
      */
-    public abstract static class Builder<S extends Schema> {
+    public abstract static class Builder<S extends Schema, B extends Builder<S, B>> {
 
         private String title;
 
@@ -43,60 +43,62 @@ public abstract class Schema {
 
         public Map<String, Object> unprocessedProperties = new HashMap<>(0);
 
-        public Builder<S> title(String title) {
+        public B title(String title) {
             this.title = title;
-            return this;
+            return getBuilder();
         }
 
-        public Builder<S> description(String description) {
+        public B description(String description) {
             this.description = description;
-            return this;
+            return getBuilder();
         }
 
-        public Builder<S> id(String id) {
+        public B id(String id) {
             this.id = id;
-            return this;
+            return getBuilder();
         }
 
         /**
          * @deprecated Use {@link #schemaLocation(SchemaLocation)} instead.
          */
         @Deprecated
-        public Builder<S> schemaLocation(String schemaLocation) {
+        public B schemaLocation(String schemaLocation) {
             return schemaLocation(SchemaLocation.parseURI(schemaLocation));
         }
 
-        public Builder<S> schemaLocation(SchemaLocation location) {
+        public B schemaLocation(SchemaLocation location) {
             this.schemaLocation = location;
-            return this;
+            return getBuilder();
         }
 
-        public Builder<S> defaultValue(Object defaultValue) {
+        public B defaultValue(Object defaultValue) {
             this.defaultValue = defaultValue;
-            return this;
+            return getBuilder();
         }
 
-        public Builder<S> nullable(Boolean nullable) {
+        public B nullable(Boolean nullable) {
             this.nullable = nullable;
-            return this;
+            return getBuilder();
         }
 
-        public Builder<S> readOnly(Boolean readOnly) {
+        public B readOnly(Boolean readOnly) {
             this.readOnly = readOnly;
-            return this;
+            return getBuilder();
         }
 
-        public Builder<S> writeOnly(Boolean writeOnly) {
+        public B writeOnly(Boolean writeOnly) {
             this.writeOnly = writeOnly;
-            return this;
+            return getBuilder();
         }
 
-        public Builder<S> unprocessedProperties(Map<String, Object> unprocessedProperties) {
+        public B unprocessedProperties(Map<String, Object> unprocessedProperties) {
             this.unprocessedProperties = unprocessedProperties;
-            return this;
+            return getBuilder();
         }
 
         public abstract S build();
+
+        protected abstract B getBuilder();
 
     }
 
@@ -127,7 +129,7 @@ public abstract class Schema {
      * @param builder
      *         the builder containing the optional title, description and id attributes of the schema
      */
-    protected Schema(Builder<?> builder) {
+    protected Schema(Builder<?, ?> builder) {
         this.title = builder.title;
         this.description = builder.description;
         this.id = builder.id;

--- a/core/src/main/java/org/everit/json/schema/StringSchema.java
+++ b/core/src/main/java/org/everit/json/schema/StringSchema.java
@@ -16,7 +16,7 @@ public class StringSchema extends Schema {
     /**
      * Builder class for {@link StringSchema}.
      */
-    public static class Builder extends Schema.Builder<StringSchema> {
+    public static class Builder extends Schema.Builder<StringSchema, Builder> {
 
         private Integer minLength;
 
@@ -27,6 +27,12 @@ public class StringSchema extends Schema {
         private boolean requiresString = true;
 
         private FormatValidator formatValidator = NONE;
+
+        @Override
+        protected Builder getBuilder()
+        {
+            return this;
+        }
 
         @Override
         public StringSchema build() {

--- a/core/src/main/java/org/everit/json/schema/TrueSchema.java
+++ b/core/src/main/java/org/everit/json/schema/TrueSchema.java
@@ -9,6 +9,12 @@ public class TrueSchema extends EmptySchema {
 
     public static class Builder extends EmptySchema.Builder {
 
+        @Override
+        protected Builder getBuilder()
+        {
+            return this;
+        }
+
         @Override public TrueSchema build() {
             return new TrueSchema(this);
         }

--- a/core/src/main/java/org/everit/json/schema/loader/AdjacentSchemaExtractionState.java
+++ b/core/src/main/java/org/everit/json/schema/loader/AdjacentSchemaExtractionState.java
@@ -10,19 +10,19 @@ class AdjacentSchemaExtractionState {
 
     private final JsonObject context;
 
-    private final Set<Schema.Builder<?>> extractedSchemas;
+    private final Set<Schema.Builder<?, ?>> extractedSchemas;
 
     AdjacentSchemaExtractionState(JsonObject context) {
         this(context, new HashSet<>());
     }
 
-    private AdjacentSchemaExtractionState(JsonObject context, Set<Schema.Builder<?>> extractedSchemas) {
+    private AdjacentSchemaExtractionState(JsonObject context, Set<Schema.Builder<?, ?>> extractedSchemas) {
         this.context = context;
         this.extractedSchemas = extractedSchemas;
     }
 
     AdjacentSchemaExtractionState reduce(ExtractionResult result) {
-        Set<Schema.Builder<?>> newExtractedSchemas = new HashSet<>(extractedSchemas.size() + result.extractedSchemas.size());
+        Set<Schema.Builder<?, ?>> newExtractedSchemas = new HashSet<>(extractedSchemas.size() + result.extractedSchemas.size());
         newExtractedSchemas.addAll(extractedSchemas);
         newExtractedSchemas.addAll(result.extractedSchemas);
         JsonObject projectedContext = new ProjectedJsonObject(context, result.consumedKeys);
@@ -33,7 +33,7 @@ class AdjacentSchemaExtractionState {
         return context;
     }
 
-    public Collection<Schema.Builder<?>> extractedSchemaBuilders() {
+    public Collection<Schema.Builder<?, ?>> extractedSchemaBuilders() {
         return extractedSchemas;
     }
 }

--- a/core/src/main/java/org/everit/json/schema/loader/CombinedSchemaLoader.java
+++ b/core/src/main/java/org/everit/json/schema/loader/CombinedSchemaLoader.java
@@ -47,7 +47,7 @@ class CombinedSchemaLoader implements SchemaExtractor {
         Set<String> presentKeys = COMB_SCHEMA_PROVIDERS.keySet().stream()
                 .filter(schemaJson::containsKey)
                 .collect(toSet());
-        Collection<Schema.Builder<?>> extractedSchemas = presentKeys.stream().map(key -> loadCombinedSchemaForKeyword(schemaJson, key))
+        Collection<Schema.Builder<?, ?>> extractedSchemas = presentKeys.stream().map(key -> loadCombinedSchemaForKeyword(schemaJson, key))
                 .collect(toList());
         return new ExtractionResult(presentKeys, extractedSchemas);
     }

--- a/core/src/main/java/org/everit/json/schema/loader/ReferenceLookup.java
+++ b/core/src/main/java/org/everit/json/schema/loader/ReferenceLookup.java
@@ -118,7 +118,7 @@ class ReferenceLookup {
         return rawObj;
     }
 
-    private Schema.Builder<?> performQueryEvaluation(String mapKey, JsonPointerEvaluator pointerEvaluator) {
+    private Schema.Builder<?, ?> performQueryEvaluation(String mapKey, JsonPointerEvaluator pointerEvaluator) {
         String absolutePointer = ReferenceResolver.resolve(ls.id, mapKey).toString();
         if (ls.pointerSchemas.containsKey(absolutePointer)) {
             return ls.pointerSchemas.get(absolutePointer).initReference(absolutePointer);
@@ -130,7 +130,7 @@ class ReferenceLookup {
     /**
      * Returns a schema builder instance after looking up the JSON pointer.
      */
-    Schema.Builder<?> lookup(String relPointerString, JsonObject ctx) {
+    Schema.Builder<?, ?> lookup(String relPointerString, JsonObject ctx) {
         String absPointerString = ReferenceResolver.resolve(ls.id, relPointerString).toString();
         if (ls.pointerSchemas.containsKey(absPointerString)) {
             return ls.pointerSchemas.get(absPointerString).initReference(absPointerString);
@@ -162,7 +162,7 @@ class ReferenceLookup {
         return refBuilder;
     }
 
-    private Schema.Builder<?> createReferenceSchema(String relPointerString, String absPointerString, JsonValue rawReferenced) {
+    private Schema.Builder<?, ?> createReferenceSchema(String relPointerString, String absPointerString, JsonValue rawReferenced) {
         ReferenceKnot knot = new ReferenceKnot();
         ReferenceSchema.Builder refBuilder = knot.initReference(relPointerString);
         ls.pointerSchemas.put(absPointerString, knot);

--- a/core/src/main/java/org/everit/json/schema/loader/SchemaExtractor.java
+++ b/core/src/main/java/org/everit/json/schema/loader/SchemaExtractor.java
@@ -67,14 +67,14 @@ class ExtractionResult {
 
     final Set<String> consumedKeys;
 
-    final Collection<Schema.Builder<?>> extractedSchemas;
+    final Collection<Schema.Builder<?, ?>> extractedSchemas;
 
-    ExtractionResult(Set<String> consumedKeys, Collection<Schema.Builder<?>> extractedSchemas) {
+    ExtractionResult(Set<String> consumedKeys, Collection<Schema.Builder<?, ?>> extractedSchemas) {
         this.consumedKeys = requireNonNull(consumedKeys, "consumedKeys cannot be null");
         this.extractedSchemas = requireNonNull(extractedSchemas, "extractedSchemas cannot be null");
     }
 
-    ExtractionResult(String consumedKeys, Collection<Schema.Builder<?>> extactedSchemas) {
+    ExtractionResult(String consumedKeys, Collection<Schema.Builder<?, ?>> extactedSchemas) {
         this(singleton(consumedKeys), extactedSchemas);
     }
 
@@ -165,7 +165,7 @@ abstract class AbstractSchemaExtractor implements SchemaExtractor {
         return new StringSchemaLoader(schemaJson.ls, config().formatValidators).load();
     }
 
-    abstract List<Schema.Builder<?>> extract();
+    abstract List<Schema.Builder<?, ?>> extract();
 }
 
 class EnumSchemaExtractor extends AbstractSchemaExtractor {
@@ -174,7 +174,7 @@ class EnumSchemaExtractor extends AbstractSchemaExtractor {
         super(defaultLoader);
     }
 
-    @Override List<Schema.Builder<?>> extract() {
+    @Override List<Schema.Builder<?, ?>> extract() {
         if (!containsKey("enum")) {
             return emptyList();
         }
@@ -193,7 +193,7 @@ class ReferenceSchemaExtractor extends AbstractSchemaExtractor {
         super(defaultLoader);
     }
 
-    @Override List<Schema.Builder<?>> extract() {
+    @Override List<Schema.Builder<?, ?>> extract() {
         if (containsKey("$ref")) {
             String ref = require("$ref").requireString();
             return singletonList(new ReferenceLookup(schemaJson.ls).lookup(ref, schemaJson));
@@ -210,8 +210,8 @@ class PropertySnifferSchemaExtractor extends AbstractSchemaExtractor {
         super(defaultLoader);
     }
 
-    @Override List<Schema.Builder<?>> extract() {
-        List<Schema.Builder<?>> builders = new ArrayList<>(1);
+    @Override List<Schema.Builder<?, ?>> extract() {
+        List<Schema.Builder<?, ?>> builders = new ArrayList<>(1);
         if (schemaHasAnyOf(config().specVersion.arrayKeywords())) {
             builders.add(buildArraySchema().requiresArray(false));
         }
@@ -246,7 +246,7 @@ class TypeBasedSchemaExtractor extends AbstractSchemaExtractor {
         super(defaultLoader);
     }
 
-    @Override List<Schema.Builder<?>> extract() {
+    @Override List<Schema.Builder<?, ?>> extract() {
         if (containsKey("type")) {
             return singletonList(require("type").canBeMappedTo(JsonArray.class, arr -> (Schema.Builder) buildAnyOfSchemaForMultipleTypes())
                     .orMappedTo(String.class, this::loadForExplicitType)
@@ -265,7 +265,7 @@ class TypeBasedSchemaExtractor extends AbstractSchemaExtractor {
         return CombinedSchema.anyOf(subschemas);
     }
 
-    private Schema.Builder<?> loadForExplicitType(String typeString) {
+    private Schema.Builder<?, ?> loadForExplicitType(String typeString) {
         switch (typeString) {
         case "string":
             return buildStringSchema().requiresString(true);
@@ -294,7 +294,7 @@ class NotSchemaExtractor extends AbstractSchemaExtractor {
         super(defaultLoader);
     }
 
-    @Override List<Schema.Builder<?>> extract() {
+    @Override List<Schema.Builder<?, ?>> extract() {
         if (containsKey("not")) {
             Schema mustNotMatch = defaultLoader.loadChild(require("not")).build();
             return singletonList(NotSchema.builder().mustNotMatch(mustNotMatch));
@@ -309,7 +309,7 @@ class ConstSchemaExtractor extends AbstractSchemaExtractor {
         super(defaultLoader);
     }
 
-    @Override List<Schema.Builder<?>> extract() {
+    @Override List<Schema.Builder<?, ?>> extract() {
         if (config().specVersion != DRAFT_4 && containsKey("const")) {
             return singletonList(ConstSchema.builder().permittedValue(require("const").unwrap()));
         } else {

--- a/core/src/main/java/org/everit/json/schema/loader/SchemaLoader.java
+++ b/core/src/main/java/org/everit/json/schema/loader/SchemaLoader.java
@@ -386,7 +386,7 @@ public class SchemaLoader {
 
     private Schema.Builder loadSchemaObject(JsonObject o) {
         AdjacentSchemaExtractionState postExtractionState = runSchemaExtractors(o);
-        Collection<Schema.Builder<?>> extractedSchemas = postExtractionState.extractedSchemaBuilders();
+        Collection<Schema.Builder<?, ?>> extractedSchemas = postExtractionState.extractedSchemaBuilders();
         Schema.Builder effectiveReturnedSchema;
         if (extractedSchemas.isEmpty()) {
             effectiveReturnedSchema = EmptySchema.builder();
@@ -455,14 +455,14 @@ public class SchemaLoader {
      * {@link Schema.Builder#build()} can be immediately used to acquire the {@link Schema}
      * instance to be used for validation
      */
-    public Schema.Builder<?> load() {
+    public Schema.Builder<?, ?> load() {
         return ls.schemaJson
                 .canBeMappedTo(Boolean.class, this::loadSchemaBoolean)
                 .orMappedTo(JsonObject.class, this::loadSchemaObject)
                 .requireAny();
     }
 
-    Schema.Builder<?> loadChild(JsonValue childJson) {
+    Schema.Builder<?, ?> loadChild(JsonValue childJson) {
         return new SchemaLoader(childJson.ls).load();
     }
 

--- a/core/src/test/java/org/everit/json/schema/NumberSchemaTest.java
+++ b/core/src/test/java/org/everit/json/schema/NumberSchemaTest.java
@@ -290,7 +290,7 @@ public class NumberSchemaTest {
 
     @Test
     public void requiresInteger_nonNullable() {
-        Schema.Builder<?> subject = NumberSchema.builder().requiresInteger(true).nullable(false);
+        Schema.Builder<?, ?> subject = NumberSchema.builder().requiresInteger(true).nullable(false);
         TestSupport.failureOf(subject)
                 .input(JSONObject.NULL)
                 .expect();

--- a/core/src/test/java/org/everit/json/schema/SchemaBuilderFluencyTest.java
+++ b/core/src/test/java/org/everit/json/schema/SchemaBuilderFluencyTest.java
@@ -1,0 +1,70 @@
+package org.everit.json.schema;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * These tests are actually compile-time validation that the superclass `Schema.Builder` returns the subclassed builder
+ * so that additional method chaining is possible. Tests are executed via `ObjectSchema.Builder` for no specific reason.
+ */
+public class SchemaBuilderFluencyTest
+{
+    @Test
+    public void title__when_called_from_subclass__returns_subclass_instance()
+    {
+        final ObjectSchema.Builder builder = ObjectSchema.builder().title(null);
+    }
+
+    @Test
+    public void description__when_called_from_subclass__returns_subclass_instance()
+    {
+        final ObjectSchema.Builder builder = ObjectSchema.builder().description(null);
+    }
+
+    @Test
+    public void id__when_called_from_subclass__returns_subclass_instance()
+    {
+        final ObjectSchema.Builder builder = ObjectSchema.builder().id(null);
+    }
+
+    @Test
+    public void schemaLocation__when_called_from_subclass_with_String__returns_subclass_instance()
+    {
+        final ObjectSchema.Builder builder = ObjectSchema.builder().schemaLocation("https://example.com/schema");
+    }
+
+    @Test
+    public void schemaLocation__when_called_from_subclass_with_SchemaLocation__returns_subclass_instance()
+    {
+        final ObjectSchema.Builder builder = ObjectSchema.builder().schemaLocation((SchemaLocation.empty()));
+    }
+
+    @Test
+    public void defaultValue__when_called_from_subclass__returns_subclass_instance()
+    {
+        final ObjectSchema.Builder builder = ObjectSchema.builder().defaultValue(null);
+    }
+
+    @Test
+    public void nullable__when_called_from_subclass__returns_subclass_instance()
+    {
+        final ObjectSchema.Builder builder = ObjectSchema.builder().nullable(null);
+    }
+
+    @Test
+    public void readOnly__when_called_from_subclass__returns_subclass_instance()
+    {
+        final ObjectSchema.Builder builder = ObjectSchema.builder().readOnly(null);
+    }
+
+    @Test
+    public void writeOnly__when_called_from_subclass__returns_subclass_instance()
+    {
+        final ObjectSchema.Builder builder = ObjectSchema.builder().writeOnly(null);
+    }
+
+    @Test
+    public void unprocessedProperties__when_called_from_subclass__returns_subclass_instance()
+    {
+        final ObjectSchema.Builder builder = ObjectSchema.builder().unprocessedProperties(null);
+    }
+}

--- a/core/src/test/java/org/everit/json/schema/TestSupport.java
+++ b/core/src/test/java/org/everit/json/schema/TestSupport.java
@@ -105,11 +105,11 @@ public class TestSupport {
         return new Failure().subject(subject);
     }
 
-    public static Failure failureOf(Schema.Builder<?> subjectBuilder) {
+    public static Failure failureOf(Schema.Builder<?, ?> subjectBuilder) {
         return failureOf(buildWithLocation(subjectBuilder));
     }
 
-    public static <S extends Schema> S buildWithLocation(Schema.Builder<S> builder) {
+    public static <S extends Schema> S buildWithLocation(Schema.Builder<S, ?> builder) {
         return builder.schemaLocation("#").build();
     }
 

--- a/core/src/test/java/org/everit/json/schema/ToStringTest.java
+++ b/core/src/test/java/org/everit/json/schema/ToStringTest.java
@@ -18,7 +18,13 @@ public class ToStringTest {
 
     static class CustomSchema extends Schema {
 
-        static class CustomSchemaBuilder extends Schema.Builder<CustomSchema> {
+        static class Builder extends Schema.Builder<CustomSchema, Builder> {
+
+            @Override
+            protected Builder getBuilder()
+            {
+                return this;
+            }
 
             @Override public CustomSchema build() {
                 return new CustomSchema(this);
@@ -31,7 +37,7 @@ public class ToStringTest {
          * @param builder
          *         the builder containing the optional title, description and id attributes of the schema
          */
-        protected CustomSchema(Builder<?> builder) {
+        protected CustomSchema(Schema.Builder<?, ?> builder) {
             super(builder);
         }
 
@@ -49,7 +55,7 @@ public class ToStringTest {
 
     @Test
     public void testCustomSchemaWithDescribePropertiesTo() {
-        String actual = new CustomSchema(new CustomSchema.CustomSchemaBuilder().description("descr-custom")).toString();
+        String actual = new CustomSchema(new CustomSchema.Builder().description("descr-custom")).toString();
         assertThat(new JSONObject(actual), sameJsonAs(LOADER.readObj("custom-schema.json")));
     }
 

--- a/core/src/test/java/org/everit/json/schema/loader/AdjacentSchemaExtractionStateTest.java
+++ b/core/src/test/java/org/everit/json/schema/loader/AdjacentSchemaExtractionStateTest.java
@@ -18,7 +18,7 @@ public class AdjacentSchemaExtractionStateTest {
                 .put("minimum", 1)
                 .build()
         ).requireObject());
-        ConstSchema.ConstSchemaBuilder schemaBuilder = ConstSchema.builder().permittedValue("2");
+        ConstSchema.Builder schemaBuilder = ConstSchema.builder().permittedValue("2");
 
         AdjacentSchemaExtractionState actual = original.reduce(new ExtractionResult("const", asList(schemaBuilder)));
 

--- a/core/src/test/java/org/everit/json/schema/loader/ReferenceLookupTest.java
+++ b/core/src/test/java/org/everit/json/schema/loader/ReferenceLookupTest.java
@@ -43,7 +43,7 @@ public class ReferenceLookupTest {
         JsonObject jsonValue = query(pointerToRef).requireObject();
         ReferenceLookup subject = new ReferenceLookup(jsonValue.ls);
         String refPointer = jsonValue.require("$ref").requireString();
-        Schema.Builder<?> actual = subject.lookup(refPointer, jsonValue);
+        Schema.Builder<?, ?> actual = subject.lookup(refPointer, jsonValue);
         return (ReferenceSchema) actual.build();
     }
 


### PR DESCRIPTION
Replacement for: https://github.com/everit-org/json-schema/pull/390

---

**Breaking Changes**

`Schema.Builder` needs to return the subclassed builder instance rather than `Builder<S>` in order to allow for fluency while building schemas. See related issue.

Note: I also renamed `ConstSchema.ConstSchemaBuilder` to just `Builder` to match the other builders for consistency. I can pull this change back out if you don't want it. Since this PR is already a breaking change, I figured it made sense.