### PR TITLE
Fix flaky test toStringWithUnprocessedProps

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -278,5 +278,11 @@
             <version>2.2</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.skyscreamer</groupId>
+            <artifactId>jsonassert</artifactId>
+            <version>1.5.1</version> <!-- Use the latest version available -->
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/core/src/test/java/org/everit/json/schema/ObjectSchemaTest.java
+++ b/core/src/test/java/org/everit/json/schema/ObjectSchemaTest.java
@@ -33,6 +33,7 @@ import org.everit.json.schema.loader.SchemaLoader;
 import org.json.JSONObject;
 import org.json.JSONPointer;
 import org.junit.jupiter.api.Test;
+import org.skyscreamer.jsonassert.JSONAssert;
 
 import com.google.re2j.Pattern;
 
@@ -396,7 +397,7 @@ public class ObjectSchemaTest {
     public void toStringTest() {
         JSONObject rawSchemaJson = loader.readObj("tostring/objectschema.json");
         String actual = SchemaLoader.load(rawSchemaJson).toString();
-        assertThat(new JSONObject(actual), sameJsonAs(rawSchemaJson));
+        JSONAssert.assertEquals(rawSchemaJson.toString(), actual, false);
     }
 
     @Test
@@ -404,7 +405,7 @@ public class ObjectSchemaTest {
         JSONObject rawSchemaJson = loader.readObj("tostring/objectschema.json");
         rawSchemaJson.remove("type");
         String actual = SchemaLoader.load(rawSchemaJson).toString();
-        assertThat(new JSONObject(actual), sameJsonAs(rawSchemaJson));
+        JSONAssert.assertEquals(rawSchemaJson.toString(), actual, false);
     }
 
     @Test
@@ -412,7 +413,7 @@ public class ObjectSchemaTest {
         JSONObject rawSchemaJson = loader.readObj("tostring/objectschema-unprocessed.json");
         Schema schema = SchemaLoader.load(rawSchemaJson);
         String actual = schema.toString();
-        assertThat(new JSONObject(actual), sameJsonAs(rawSchemaJson));
+        JSONAssert.assertEquals(rawSchemaJson.toString(), actual, false);
     }
 
     @Test


### PR DESCRIPTION
This PR addresses issue #515 
I ran mvn edu.illinois:nondex-maven-plugin:2.1.7:nondex -Dtest=org.everit.json.schema.ObjectSchemaTest#toStringWithUnprocessedProps -DfailIfNoTests=false and notice test failure.

For the test: toStringWithUnprocessedProps, the usage of sameJsonAs function, which eventually uses the function deepEqualArrays, enforces strict order of the data in the Json files, making it a potential flaky test.

The fix utilizes [JSONAssert](https://github.com/skyscreamer/JSONassert) which compares Jsons but forgive ordering of the data.