### PR TITLE
Add ability to get subschemas of CombinedSchema in insertion order

### DIFF
--- a/core/src/main/java/org/everit/json/schema/CombinedSchema.java
+++ b/core/src/main/java/org/everit/json/schema/CombinedSchema.java
@@ -154,6 +154,8 @@ public class CombinedSchema extends Schema {
 
     private final boolean synthetic;
 
+    private final Collection<Schema> orderedSubschemas;
+
     private final Collection<Schema> subschemas;
 
     private final ValidationCriterion criterion;
@@ -168,6 +170,7 @@ public class CombinedSchema extends Schema {
         super(builder);
         this.synthetic = builder.synthetic;
         this.criterion = requireNonNull(builder.criterion, "criterion cannot be null");
+        this.orderedSubschemas = builder.subschemas;
         this.subschemas = sortByCombinedFirst(requireNonNull(builder.subschemas, "subschemas cannot be null"));
     }
 
@@ -189,6 +192,14 @@ public class CombinedSchema extends Schema {
 
     public ValidationCriterion getCriterion() {
         return criterion;
+    }
+
+    /**
+     * Returns the subschemas in the order they were added.
+     * @return the subschemas in insertion order
+     */
+    public Collection<Schema> getOrderedSubschemas() {
+        return orderedSubschemas;
     }
 
     public Collection<Schema> getSubschemas() {

--- a/core/src/test/java/org/everit/json/schema/CombinedSchemaTest.java
+++ b/core/src/test/java/org/everit/json/schema/CombinedSchemaTest.java
@@ -79,6 +79,18 @@ public class CombinedSchemaTest {
         assertEquals(booleanSchema2, subschemas[5]);
         assertEquals(emptySchema2, subschemas[6]);
         assertEquals(nullSchema2, subschemas[7]);
+
+        subschemas = subject.getOrderedSubschemas().toArray();
+
+        assertEquals(8, subschemas.length);
+        assertEquals(nullSchema1, subschemas[0]);
+        assertEquals(emptySchema1, subschemas[1]);
+        assertEquals(booleanSchema1, subschemas[2]);
+        assertEquals(subcombined1, subschemas[3]);
+        assertEquals(booleanSchema2, subschemas[4]);
+        assertEquals(emptySchema2, subschemas[5]);
+        assertEquals(nullSchema2, subschemas[6]);
+        assertEquals(subcombined2, subschemas[7]);
     }
 
     @Test
@@ -172,7 +184,7 @@ public class CombinedSchemaTest {
     public void equalsVerifier() {
         EqualsVerifier.forClass(CombinedSchema.class)
                 .withRedefinedSuperclass()
-                .withIgnoredFields("schemaLocation", "location")
+                .withIgnoredFields("schemaLocation", "location", "orderedSubschemas")
                 .suppress(Warning.STRICT_INHERITANCE)
                 .verify();
     }


### PR DESCRIPTION
Add the ability to get subschemas of CombinedSchema in insertion order.

For context, the code in [Confluent Schema Registry](https://github.com/confluentinc/schema-registry) is currently using version 1.14.3 of this library.  We found that when we upgraded to 1.14.4 some of our code no longer worked because we were relying on the order of schemas returned from `CombinedSchema.getSubschemas()`.  That order changed in 1.14.4 due to https://github.com/everit-org/json-schema/pull/498.  It turns out the order was not deterministic anyway for the leading subschemas, but we hadn't yet hit this problem.  But now while the order is deterministic for any one specific JVM execution, it may be different between different executions and different JVMs because it uses the `hashCode` method to sort the subschemas.

Our code works best with the insertion order, which is deterministic (across executions and JVMs) for a given `CombinedSchema`.  Therefore a modest workaround that works for us is to add a `CombinedSchema.getOrderedSubschemas` method and for the Confluent code to rely on that method instead of `CombinedSchema.getSubschemas`.