### PR TITLE
Handle multiple anyOf subschemas in ToStringVisitor

### DIFF
--- a/core/src/main/java/org/everit/json/schema/CombinedSchema.java
+++ b/core/src/main/java/org/everit/json/schema/CombinedSchema.java
@@ -195,6 +195,14 @@ public class CombinedSchema extends Schema {
         return subschemas;
     }
 
+    public boolean hasMultipleCombinedSchemasOfSameCriterion() {
+        return subschemas.stream()
+            .filter(schema -> schema instanceof CombinedSchema)
+            .collect(Collectors.groupingBy(schema -> ((CombinedSchema) schema).getCriterion(), Collectors.counting()))
+            .values().stream()
+            .anyMatch(count -> count > 1);
+    }
+
     boolean isSynthetic() {
         return synthetic;
     }

--- a/core/src/main/java/org/everit/json/schema/ToStringVisitor.java
+++ b/core/src/main/java/org/everit/json/schema/ToStringVisitor.java
@@ -253,7 +253,8 @@ class ToStringVisitor extends Visitor {
     @Override void visitCombinedSchema(CombinedSchema combinedSchema) {
         printInJsonObject(() -> {
             super.visitCombinedSchema(combinedSchema);
-            if (combinedSchema.isSynthetic()) {
+            if (combinedSchema.isSynthetic()
+                && !combinedSchema.hasMultipleCombinedSchemasOfSameCriterion()) {
                 combinedSchema.getSubschemas().forEach(subschema -> {
                     this.skipNextObject = true;
                     super.visit(subschema);

--- a/core/src/test/java/org/everit/json/schema/ToStringTest.java
+++ b/core/src/test/java/org/everit/json/schema/ToStringTest.java
@@ -4,10 +4,12 @@ import static org.everit.json.schema.FalseSchema.INSTANCE;
 import static org.everit.json.schema.JSONMatcher.sameJsonAs;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.io.StringWriter;
 
 import org.everit.json.schema.internal.JSONPrinter;
+import org.everit.json.schema.loader.SchemaLoader;
 import org.json.JSONObject;
 
 import com.google.common.collect.ImmutableMap;
@@ -126,4 +128,30 @@ public class ToStringTest {
         assertThat(new JSONObject(actual), sameJsonAs(rawSchemaJson));
     }
 
+
+    @Test
+    public void multipleAnyOf() {
+        String schemaString = "{\n"
+            + "  \"$schema\": \"http://json-schema.org/draft-07/schema#\",\n"
+            + "  \"type\": \"object\",\n"
+            + "  \"properties\": {\n"
+            + "    \"updatedAt\": {\n"
+            + "      \"type\": [\n"
+            + "        \"string\",\n"
+            + "        \"null\"\n"
+            + "      ],\n"
+            + "      \"anyOf\": [\n"
+            + "        {\n"
+            + "          \"format\": \"date-time\"\n"
+            + "        },\n"
+            + "        {\n"
+            + "          \"format\": \"date\"\n"
+            + "        }\n"
+            + "      ]\n"
+            + "    }\n"
+            + "  }\n"
+            + "}";
+        Schema schema = SchemaLoader.load(new JSONObject(schemaString));
+        assertNotNull(schema.toString());
+    }
 }


### PR DESCRIPTION
When converting a Schema to a string, if a synthetic allOf schema has multiple subschemas of the same criterion, then emit the allOf to prevent `org.json.JSONException: Duplicate key "anyOf"`

Fixes https://github.com/everit-org/json-schema/issues/520
