### PR TITLE
3rd alternative to make subschema ordering consistent

### DIFF
--- a/core/src/main/java/org/everit/json/schema/CombinedSchema.java
+++ b/core/src/main/java/org/everit/json/schema/CombinedSchema.java
@@ -154,6 +154,8 @@ public class CombinedSchema extends Schema {
 
     private final boolean synthetic;
 
+    private final Collection<Schema> orderedSubschemas;
+
     private final Collection<Schema> subschemas;
 
     private final ValidationCriterion criterion;
@@ -168,6 +170,7 @@ public class CombinedSchema extends Schema {
         super(builder);
         this.synthetic = builder.synthetic;
         this.criterion = requireNonNull(builder.criterion, "criterion cannot be null");
+        this.orderedSubschemas = builder.subschemas;
         this.subschemas = sortByCombinedFirst(requireNonNull(builder.subschemas, "subschemas cannot be null"));
     }
 
@@ -189,6 +192,14 @@ public class CombinedSchema extends Schema {
 
     public ValidationCriterion getCriterion() {
         return criterion;
+    }
+
+    /**
+     * Returns the subschemas in the order they were added.
+     * @return the subschemas in insertion order
+     */
+    public Collection<Schema> getOrderedSubschemas() {
+        return orderedSubschemas;
     }
 
     public Collection<Schema> getSubschemas() {

--- a/core/src/main/java/org/everit/json/schema/CombinedSchema.java
+++ b/core/src/main/java/org/everit/json/schema/CombinedSchema.java
@@ -179,13 +179,13 @@ public class CombinedSchema extends Schema {
 
     private static class SubschemaComparator implements Comparator<Schema> {
 
-        private final Map<Schema, Integer> originalPositionsOfSchemas;
+        private final Map<Integer, Integer> originalPositionsOfSchemas;
 
         SubschemaComparator(Collection<Schema> originalSubschemas) {
             originalPositionsOfSchemas = new HashMap<>(originalSubschemas.size());
             int index = 0;
             for (Schema schema : originalSubschemas) {
-                originalPositionsOfSchemas.put(schema, index);
+                originalPositionsOfSchemas.put(System.identityHashCode(schema), index);
                 ++index;
             }
         }
@@ -195,7 +195,9 @@ public class CombinedSchema extends Schema {
         public int compare(Schema lschema, Schema rschema) {
             boolean leftSchemaIsCombined = lschema instanceof CombinedSchema;
             boolean rightIsCombined = rschema instanceof CombinedSchema;
-            int defaultRetval = originalPositionsOfSchemas.get(lschema) - originalPositionsOfSchemas.get(rschema);
+            Integer lschemaIndex = originalPositionsOfSchemas.get(System.identityHashCode(lschema));
+            Integer rschemaIndex = originalPositionsOfSchemas.get(System.identityHashCode(rschema));
+            int defaultRetval = lschemaIndex - rschemaIndex;
             return leftSchemaIsCombined ?
                     (rightIsCombined ? defaultRetval : -1) :
                     (rightIsCombined ? 1 : defaultRetval);

--- a/core/src/test/java/org/everit/json/schema/CombinedSchemaTest.java
+++ b/core/src/test/java/org/everit/json/schema/CombinedSchemaTest.java
@@ -45,14 +45,13 @@ public class CombinedSchemaTest {
                 .build();
 
         BooleanSchema booleanSchema1 = BooleanSchema.INSTANCE;
-        BooleanSchema booleanSchema2 = BooleanSchema.INSTANCE;
+        BooleanSchema booleanSchema2 = BooleanSchema.builder().build();
 
         EmptySchema emptySchema1 = EmptySchema.INSTANCE;
-        EmptySchema emptySchema2 = EmptySchema.INSTANCE;
+        EmptySchema emptySchema2 = EmptySchema.builder().build();
 
         NullSchema nullSchema1 = NullSchema.INSTANCE;
-        NullSchema nullSchema2 = NullSchema.INSTANCE;
-
+        NullSchema nullSchema2 = NullSchema.builder().build();
         // subschemas of type CombinedSchema should bubble to the top,
         // all other schema types should remain in same order
         CombinedSchema subject = CombinedSchema.builder()
@@ -62,7 +61,7 @@ public class CombinedSchemaTest {
                 .subschema(booleanSchema1)
                 .subschema(subcombined1)
                 .subschema(booleanSchema2)
-//                .subschema(emptySchema2)
+                .subschema(emptySchema2)
                 .subschema(nullSchema2)
                 .subschema(subcombined2)
                 .isSynthetic(true)
@@ -78,22 +77,10 @@ public class CombinedSchemaTest {
                 emptySchema1,
                 booleanSchema1,
                 booleanSchema2,
-//                emptySchema2,
+                emptySchema2,
                 nullSchema2
 
         }, subschemas);
-
-        subschemas = subject.getOrderedSubschemas().toArray();
-
-        assertEquals(8, subschemas.length);
-        assertEquals(nullSchema1, subschemas[0]);
-        assertEquals(emptySchema1, subschemas[1]);
-        assertEquals(booleanSchema1, subschemas[2]);
-        assertEquals(subcombined1, subschemas[3]);
-        assertEquals(booleanSchema2, subschemas[4]);
-        assertEquals(emptySchema2, subschemas[5]);
-        assertEquals(nullSchema2, subschemas[6]);
-        assertEquals(subcombined2, subschemas[7]);
     }
 
     @Test

--- a/core/src/test/java/org/everit/json/schema/CombinedSchemaTest.java
+++ b/core/src/test/java/org/everit/json/schema/CombinedSchemaTest.java
@@ -79,6 +79,18 @@ public class CombinedSchemaTest {
         assertEquals(booleanSchema2, subschemas[5]);
         assertEquals(emptySchema2, subschemas[6]);
         assertEquals(nullSchema2, subschemas[7]);
+
+        subschemas = subject.getOrderedSubschemas().toArray();
+
+        assertEquals(8, subschemas.length);
+        assertEquals(nullSchema1, subschemas[0]);
+        assertEquals(emptySchema1, subschemas[1]);
+        assertEquals(booleanSchema1, subschemas[2]);
+        assertEquals(subcombined1, subschemas[3]);
+        assertEquals(booleanSchema2, subschemas[4]);
+        assertEquals(emptySchema2, subschemas[5]);
+        assertEquals(nullSchema2, subschemas[6]);
+        assertEquals(subcombined2, subschemas[7]);
     }
 
     @Test
@@ -172,7 +184,7 @@ public class CombinedSchemaTest {
     public void equalsVerifier() {
         EqualsVerifier.forClass(CombinedSchema.class)
                 .withRedefinedSuperclass()
-                .withIgnoredFields("schemaLocation", "location")
+                .withIgnoredFields("schemaLocation", "location", "orderedSubschemas")
                 .suppress(Warning.STRICT_INHERITANCE)
                 .verify();
     }

--- a/core/src/test/java/org/everit/json/schema/CombinedSchemaTest.java
+++ b/core/src/test/java/org/everit/json/schema/CombinedSchemaTest.java
@@ -62,7 +62,7 @@ public class CombinedSchemaTest {
                 .subschema(booleanSchema1)
                 .subschema(subcombined1)
                 .subschema(booleanSchema2)
-                .subschema(emptySchema2)
+//                .subschema(emptySchema2)
                 .subschema(nullSchema2)
                 .subschema(subcombined2)
                 .isSynthetic(true)
@@ -70,15 +70,18 @@ public class CombinedSchemaTest {
 
         Object[] subschemas = subject.getSubschemas().toArray();
 
-        assertEquals(8, subschemas.length);
-        assertEquals(subcombined1, subschemas[0]);
-        assertEquals(subcombined2, subschemas[1]);
-        assertEquals(nullSchema1, subschemas[2]);
-        assertEquals(emptySchema1, subschemas[3]);
-        assertEquals(booleanSchema1, subschemas[4]);
-        assertEquals(booleanSchema2, subschemas[5]);
-        assertEquals(emptySchema2, subschemas[6]);
-        assertEquals(nullSchema2, subschemas[7]);
+//        assertEquals(8, subschemas.length);
+        assertArrayEquals(new Object[]{
+                subcombined1,
+                subcombined2,
+                nullSchema1,
+                emptySchema1,
+                booleanSchema1,
+                booleanSchema2,
+//                emptySchema2,
+                nullSchema2
+
+        }, subschemas);
 
         subschemas = subject.getOrderedSubschemas().toArray();
 


### PR DESCRIPTION
Sorts subschemas using a comparator that
 - takes combined schemas first
 - sorts the rest of them by insertion order (by remembering the order in the before-sorting collection)

This is a 3rd alternative to #522  and #519 

Hello @rayokota which one do you prefer more?