### PR TITLE
make Schema instances serializable

### DIFF
--- a/core/src/main/java/org/everit/json/schema/Schema.java
+++ b/core/src/main/java/org/everit/json/schema/Schema.java
@@ -2,6 +2,7 @@ package org.everit.json.schema;
 
 import static java.util.Collections.unmodifiableMap;
 
+import java.io.Serializable;
 import java.io.StringWriter;
 import java.util.HashMap;
 import java.util.Map;
@@ -13,7 +14,7 @@ import org.json.JSONWriter;
 /**
  * Superclass of all other schema validator classes of this package.
  */
-public abstract class Schema {
+public abstract class Schema implements Serializable {
 
     /**
      * Abstract builder class for the builder classes of {@code Schema} subclasses. This builder is

--- a/core/src/main/java/org/everit/json/schema/SchemaLocation.java
+++ b/core/src/main/java/org/everit/json/schema/SchemaLocation.java
@@ -3,13 +3,14 @@ package org.everit.json.schema;
 import static java.util.Collections.emptyList;
 import static java.util.Objects.requireNonNull;
 
+import java.io.Serializable;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
-public class SchemaLocation {
+public class SchemaLocation implements Serializable {
 
     public static final SchemaLocation empty() {
         return new SchemaLocation(null, emptyList());

--- a/core/src/test/java/org/everit/json/schema/loader/SchemaSerializationTest.java
+++ b/core/src/test/java/org/everit/json/schema/loader/SchemaSerializationTest.java
@@ -1,0 +1,37 @@
+package org.everit.json.schema.loader;
+
+import org.everit.json.schema.ResourceLoader;
+import org.everit.json.schema.Schema;
+import org.json.JSONObject;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class SchemaSerializationTest {
+
+    private static JSONObject SCHEMA_JSON = ResourceLoader.DEFAULT.readObj("testschemas.json").getJSONObject("pointerResolution");
+
+    @Test
+    void testBackAndForthSerializationWithPointer()
+            throws Exception {
+        Schema loaded = SchemaLoader.load(SCHEMA_JSON);
+
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        ObjectOutputStream oos = new ObjectOutputStream(baos);
+
+        oos.writeObject(loaded);
+
+        oos.flush();
+        baos.flush();
+        ByteArrayInputStream bais = new ByteArrayInputStream(baos.toByteArray());
+        ObjectInputStream ois = new ObjectInputStream(bais);
+        Schema readBack = (Schema) ois.readObject();
+        assertEquals(loaded, readBack);
+    }
+}


### PR DESCRIPTION
Hello @samie41 this PR makes Schema instances Serializable, so you can cache them using plain java serialization. It is probably faster than serializing into json and then re-reading using the SchemaLoader. 

Do you think it would work?