### PR TITLE
Fix comparator to avoid subtraction overflow

### DIFF
--- a/core/src/main/java/org/everit/json/schema/CombinedSchema.java
+++ b/core/src/main/java/org/everit/json/schema/CombinedSchema.java
@@ -177,7 +177,7 @@ public class CombinedSchema extends Schema {
     private static int compareBySchemaType(Schema lschema, Schema rschema) {
         boolean leftSchemaIsCombined = lschema instanceof CombinedSchema;
         boolean rightIsCombined = rschema instanceof CombinedSchema;
-        int defaultRetval = lschema.hashCode() - rschema.hashCode();
+        int defaultRetval = Integer.compare(lschema.hashCode(), rschema.hashCode());
         return leftSchemaIsCombined ?
                 (rightIsCombined ? defaultRetval : -1) :
                 (rightIsCombined ? 1 : defaultRetval);


### PR DESCRIPTION
We're seeing the below exception in our production environment.  I believe it's because the subtraction operation can overflow.  This PR fixes the overflow.

Here is an analysis from one of our tools:

> Integer Overflow Issue:
> If lschema.hashCode() is a large positive integer and rschema.hashCode() is a large negative integer (or vice-versa), their subtraction can overflow (or underflow) the int range. This can result in a value with an incorrect sign.
> 
> For example:
> Let s1, s2, s3 all be CombinedSchema instances.
> 
> s1.hashCode() = 2_000_000_000
> s2.hashCode() = 0
> s3.hashCode() = -2_000_000_000
> According to their hash codes, the correct order should be s1 > s2 > s3.
> 
> Let's evaluate using the comparator:
> 
> compareBySchemaType(s1, s2):
> defaultRetval = s1.hashCode() - s2.hashCode() = 2_000_000_000 - 0 = 2_000_000_000 (positive).
> This implies s1 > s2. (Correct)
> 
> compareBySchemaType(s2, s3):
> defaultRetval = s2.hashCode() - s3.hashCode() = 0 - (-2_000_000_000) = 2_000_000_000 (positive).
> This implies s2 > s3. (Correct)
> 
> For transitivity, compareBySchemaType(s1, s3) must also be positive.
> defaultRetval = s1.hashCode() - s3.hashCode() = 2_000_000_000 - (-2_000_000_000) = 4_000_000_000.
> This value (4_000_000_000) is outside the range of a Java int (-2_147_483_648 to 2_147_483_647). The actual result of this subtraction in Java will be 4_000_000_000 - 2^32 = -294_967_296 (a negative number due to overflow).
> So, compareBySchemaType(s1, s3) returns a negative value.
> This implies s1 < s3.
> 
> We have s1 > s2 and s2 > s3, but the comparator incorrectly concludes s1 < s3. This is a clear violation of transitivity.
> 

```
Caused by: java.lang.IllegalArgumentException: Comparison method violates its general contract!
    at java.base/java.util.TimSort.mergeLo(TimSort.java:781)
    at java.base/java.util.TimSort.mergeAt(TimSort.java:518)
    at java.base/java.util.TimSort.mergeCollapse(TimSort.java:448)
    at java.base/java.util.TimSort.sort(TimSort.java:245)
    at java.base/java.util.Arrays.sort(Arrays.java:1307)
    at java.base/java.util.stream.SortedOps$SizedRefSortingSink.end(SortedOps.java:353)
    at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:510)
    at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:499)
    at java.base/java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:921)
    at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
    at java.base/java.util.stream.ReferencePipeline.collect(ReferencePipeline.java:682)
    at org.everit.json.schema.CombinedSchema.sortByCombinedFirst(CombinedSchema.java:190)
    at org.everit.json.schema.CombinedSchema.<init>(CombinedSchema.java:174)
    at io.confluent.kafka.schemaregistry.json.schema.CombinedSchemaExt.<init>(CombinedSchemaExt.java:91)
    at io.confluent.kafka.schemaregistry.json.schema.CombinedSchemaExt$Builder.build(CombinedSchemaExt.java:37)
    at io.confluent.kafka.schemaregistry.json.schema.CombinedSchemaExt$Builder.build(CombinedSchemaExt.java:31)
    at io.confluent.kafka.schemaregistry.json.schema.SchemaTranslator$SchemaContext.schema(SchemaTranslator.java:649)
    at io.confluent.kafka.schemaregistry.json.schema.SchemaTranslator$SchemaContext.join(SchemaTranslator.java:658)
    at io.confluent.kafka.schemaregistry.json.schema.SchemaTranslator$SchemaContext.join(SchemaTranslator.java:653)
    at io.confluent.kafka.schemaregistry.json.schema.SchemaTranslator.accumulate(SchemaTranslator.java:128)
    at io.confluent.kafka.schemaregistry.json.schema.SchemaTranslator.accumulate(SchemaTranslator.java:105)
    ... 111 more
```